### PR TITLE
Setup CI through GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,75 @@
+name: CI of Tasks
+
+on:
+  push:
+    paths-ignore:
+      # Changes to those files don't mandate running CI
+      - ".github/workflows/package.yml"
+      - "debian/**"
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-16.04, ubuntu-18.04, macos-latest, windows-latest]
+        build-type: [Debug, RelWithDebInfo]
+        compiler: [gcc, clang]
+        exclude:
+          # Only default compiler on macos-latest and windows-latest
+          - os: macos-latest
+            compiler: clang
+          - os: windows-latest
+            compiler: clang
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: Install dependencies
+      uses: jrl-umi3218/github-actions/install-dependencies@master
+      with:
+        compiler: ${{ matrix.compiler }}
+        build-type: ${{ matrix.build-type }}
+        ubuntu: |
+          apt: libeigen3-dev doxygen doxygen-latex libboost-all-dev
+        macos: |
+          cask: gfortran
+          brew: eigen boost
+        windows: |
+          github:
+            - path: eigenteam/eigen-git-mirror
+              ref: 3.3.7
+        github: |
+          - path: jrl-umi3218/eigen-quadprog
+            options: -DPYTHON_BINDING:BOOL=OFF
+          - path: jrl-umi3218/eigen-qld
+            options: -DPYTHON_BINDING:BOOL=OFF
+    - name: Build and test
+      uses: jrl-umi3218/github-actions/build-cmake-project@master
+      with:
+        compiler: ${{ matrix.compiler }}
+        build-type: ${{ matrix.build-type }}
+        options: -DPYTHON_BINDING:BOOL=OFF
+    - name: Upload documentation
+      # Only run on master branch and for one configuration
+      if: matrix.os == 'ubuntu-18.04' && matrix.build-type == 'RelWithDebInfo' && matrix.compiler == 'gcc' && github.ref == 'refs/heads/master'
+      uses: jrl-umi3218/github-actions/upload-documentation@master
+      with:
+        GH_USER: gergondet
+        GH_PAGES_TOKEN: ${{ secrets.GH_PAGES_TOKEN }}
+    - name: Slack Notification
+      if: failure()
+      uses: archive/github-actions-slack@master
+      with:
+        slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_TOKEN }}
+        slack-channel: '#ci'
+        slack-text: >
+          [copra] Build *${{ matrix.os }}/${{ matrix.build-type }} (${{ matrix.compiler }})* failed on ${{ github.ref }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,14 +17,16 @@
 
 # Version minimum
 cmake_minimum_required(VERSION 3.1.3)
-include(cmake/base.cmake)
-include(cmake/msvc-specific.cmake)
-include(optional_qps.cmake)
 
 set(PROJECT_NAME copra)
 set(PROJECT_DESCRIPTION "This library is an implementation of a linear model predictive control")
 set(PROJECT_URL "https://github.com/vsamy/copra")
 set(PROJECT_DEBUG_POSTFIX "_d")
+set(PROJECT_VERSION 1.2.1)
+
+include(cmake/base.cmake)
+include(cmake/msvc-specific.cmake)
+include(optional_qps.cmake)
 
 # SET(CXX_DISABLE_WERROR True)
 set(DOXYGEN_USE_MATHJAX "YES")
@@ -33,9 +35,8 @@ set(CMAKE_CXX_STANDARD 14)
 option(PYTHON_BINDING "Generate python bindings." OFF)
 option(BUILD_TESTING "Build unit tests." ON)
 
-project(${PROJECT_NAME} CXX)
+project(${PROJECT_NAME} LANGUAGES CXX VERSION ${PROJECT_VERSION})
 
-setup_project()
 set(INSTALL_GENERATED_HEADERS OFF)
 
 if(MSVC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,6 +60,7 @@ endif()
 
 add_library(${PROJECT_NAME} SHARED ${SOURCES} ${HEADERS})
 set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS "-Dcopra_EXPORTS")
+set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR} VERSION ${PROJECT_VERSION})
 target_compile_definitions(${PROJECT_NAME} PUBLIC ${COPRA_COMPILE_DEFS})
 target_include_directories(${PROJECT_NAME} PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
 target_link_libraries(${PROJECT_NAME} PUBLIC eigen-quadprog::eigen-quadprog)


### PR DESCRIPTION
This PR is setting up CI through GitHub Actions

It also sets `PROJECT_VERSION` manually rather than relying on git to compute it

@vsamy for this to be fully functional (Slack notifications on build failures and documentation upload) I need to setup some secrets in the project settings, could you give me admin access? We also need to setup a gh-pages branch similar to this: https://github.com/jrl-umi3218/eigen-quadprog/commit/0bb4c1a831f8bf447e62271e67bb3bf7d2134cc9 with minor mofidications