### PR TITLE
LMPC with optimization of the initial state

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ include(optional_qps.cmake)
 # SET(CXX_DISABLE_WERROR True)
 set(DOXYGEN_USE_MATHJAX "YES")
 set(CMAKE_CXX_STANDARD 14)
+set(EIGEN_MPL2_ONLY 1)
 
 option(PYTHON_BINDING "Generate python bindings." OFF)
 option(BUILD_TESTING "Build unit tests." ON)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ solvers. Python bindings are available.
 ![main image](doc/pictures/walkgen-com.png "Computation of the CoM preview using the MPC")
 *@Stephane Caron*
 
-This work was originally made by [Vincent Samy](https://github.com/vsamy).
+This work was originally made by [Vincent Samy](https://github.com/vsamy) and extended by [Niels Dehio](https://github.com/ndehio).
 
 Copra is licensed under the [BSD-2-Clause](https://opensource.org/licenses/BSD-2-Clause). However, its default QP solver (eigen-quadprog) is licensed under the LGPL-2 and this cannot be changed. Please be aware of the related restrictions if you plan to work with copra. At a later date, we might switch copra default QP solver to one with a less restrictive license.
 
@@ -105,3 +105,22 @@ You can also check out unit tests, as well as the following two examples:
 
 * [C++ example of Copra](https://vsamy.github.io/en/blog/copra-example-cpp)
 * [Python example of Copra](https://vsamy.github.io/en/blog/copra-example-python)
+
+### Reference
+
+Linear model predictive control including optimization of the initial state employing COPRA has been described in
+
+```
+@unpublished{Dehio2021ICRA,
+  title = {Safe Impacts with Soft Contacts Based on Learned Deformations},
+  author = {Dehio, Niels and Kheddar, Abderrahmane},
+  booktitle={IEEE Int. Conf. on Robotics and Automation},
+  pdf = {https://hal.archives-ouvertes.fr/hal-02973947/document},
+  url = {https://hal.archives-ouvertes.fr/hal-02973947},
+  year = {2021}
+}
+```
+
+Writing code takes time.
+If this implementation is useful for your research, please cite the related publication.
+

--- a/include/InitialStateLMPC.h
+++ b/include/InitialStateLMPC.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2016-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include "LMPC.h"
+#include <Eigen/LU>
+
+namespace copra {
+
+
+/**
+ * The controller itself.
+ * This class gives all the needed composants for performing a model preview control including optimization of the initial state.
+ * \warning This class waits for a discretized system ! Continuous systems are not implemented.
+ */
+class COPRA_DLLAPI InitialStateLMPC : public LMPC {
+public:
+    /**
+     * Initialize problem variables to default and get the desired solver
+     * You need to call initializeController before using the MPCTypeFull
+     * \param sFlag The flag corresponding to the desired solver.
+     */
+    InitialStateLMPC(SolverFlag sFlag = SolverFlag::DEFAULT);
+
+    /**
+     * Initialize problem variables w.r.t. the PreviewSystem and get the desired
+     * solver
+     * \param ps A preview system to make a copy from.
+     * \param sFlag The flag corresponding to the desired solver.
+     */
+    InitialStateLMPC(const std::shared_ptr<PreviewSystem>& ps, SolverFlag sFlag = SolverFlag::DEFAULT);
+
+    /**
+     * Initialize the controller with regard to the preview system.
+     * This function needs to be called each time the system dimension changes.
+     * \param ps The preview system
+     */
+    void initializeController(const std::shared_ptr<PreviewSystem>& ps);
+
+    /**
+     * Solve the system.
+     * \return True if a solution has been found.
+     * Fill Phi, Psi, xi in PreviewSystem
+     * Fill A, b in Constraints
+     */
+    bool solve();
+
+    /**
+     * Get the solver result.
+     * \return The initial-state vector \f$x_{0}\f$.
+     */
+    Eigen::VectorXd initialState() const noexcept;
+    
+    /**
+     * Get the solver result.
+     * \return The control vector \f$U\f$.
+     */
+    Eigen::VectorXd control() const noexcept;
+
+    /**
+     * Get the preview trajectory.
+     * \return The trajectory vector \f$X\f$.
+     */
+    Eigen::VectorXd trajectory() const noexcept;
+
+    /**
+     * Add a cost related to the initial state
+     */
+    void resetInitialStateCost(const Eigen::MatrixXd& R, const Eigen::VectorXd& r);
+
+    /**
+     * Add lower and upper bounds for the initial state 
+     */
+    void resetInitialStateBounds(const Eigen::VectorXd& l, const Eigen::VectorXd& u);
+
+protected:
+
+    /**
+     * Resize internal matrices and vectors to default.
+     */
+    void clearConstraintMatrices();
+
+    /**
+     * Update the system and its constraints.
+     */
+    void updateSystem();
+
+    /**
+     * QP-like format.
+     */
+    void makeQPForm();
+
+protected:
+    std::unique_ptr<SolverInterface> sol_;
+
+    Eigen::MatrixXd R_;
+    Eigen::VectorXd r_;
+    Eigen::MatrixXd E_;
+    Eigen::VectorXd f_;
+    Eigen::VectorXd l_;
+    Eigen::VectorXd u_;
+
+    Eigen::MatrixXd Yeq_;
+    Eigen::VectorXd zeq_;
+    Eigen::MatrixXd Yineq_;
+    Eigen::VectorXd zineq_;
+
+    Eigen::MatrixXd newQ_;
+    Eigen::VectorXd newc_;
+    Eigen::VectorXd newlb_;
+    Eigen::VectorXd newub_;
+
+    Eigen::MatrixXd newAeq_;
+    Eigen::VectorXd newbeq_;
+    Eigen::MatrixXd newAineq_;
+    Eigen::VectorXd newbineq_;
+};
+
+} // namespace pc

--- a/include/InitialStateLMPC.h
+++ b/include/InitialStateLMPC.h
@@ -93,8 +93,6 @@ protected:
     void makeQPForm();
 
 protected:
-    std::unique_ptr<SolverInterface> sol_;
-
     Eigen::MatrixXd R_;
     Eigen::VectorXd r_;
     Eigen::MatrixXd E_;

--- a/include/InitialStateLMPC.h
+++ b/include/InitialStateLMPC.h
@@ -97,8 +97,8 @@ protected:
     Eigen::VectorXd r_;
     Eigen::MatrixXd E_;
     Eigen::VectorXd f_;
-    Eigen::VectorXd l_;
-    Eigen::VectorXd u_;
+    Eigen::VectorXd l_; //initial state lower bound
+    Eigen::VectorXd u_; //initial state upper bound
 
     Eigen::MatrixXd Yeq_;
     Eigen::VectorXd zeq_;

--- a/include/InitialStateLMPC.h
+++ b/include/InitialStateLMPC.h
@@ -37,7 +37,7 @@ public:
      * This function needs to be called each time the system dimension changes.
      * \param ps The preview system
      */
-    void initializeController(const std::shared_ptr<PreviewSystem>& ps);
+    void initializeController(const std::shared_ptr<PreviewSystem>& ps) override;
 
     /**
      * Solve the system.
@@ -45,7 +45,7 @@ public:
      * Fill Phi, Psi, xi in PreviewSystem
      * Fill A, b in Constraints
      */
-    bool solve();
+    bool solve() override;
 
     /**
      * Get the solver result.
@@ -57,13 +57,13 @@ public:
      * Get the solver result.
      * \return The control vector \f$U\f$.
      */
-    Eigen::VectorXd control() const noexcept;
+    const Eigen::VectorXd& control() const noexcept override;
 
     /**
      * Get the preview trajectory.
      * \return The trajectory vector \f$X\f$.
      */
-    Eigen::VectorXd trajectory() const noexcept;
+    Eigen::VectorXd trajectory() const noexcept override;
 
     /**
      * Add a cost related to the initial state
@@ -80,17 +80,17 @@ protected:
     /**
      * Resize internal matrices and vectors to default.
      */
-    void clearConstraintMatrices();
+    void clearConstraintMatrices() override;
 
     /**
      * Update the system and its constraints.
      */
-    void updateSystem();
+    void updateSystem() override;
 
     /**
      * QP-like format.
      */
-    void makeQPForm();
+    void makeQPForm() override;
 
 protected:
     Eigen::MatrixXd R_;
@@ -114,6 +114,8 @@ protected:
     Eigen::VectorXd newbeq_;
     Eigen::MatrixXd newAineq_;
     Eigen::VectorXd newbineq_;
+
+    Eigen::VectorXd control_;
 };
 
 } // namespace pc

--- a/include/LMPC.h
+++ b/include/LMPC.h
@@ -55,9 +55,7 @@ public:
      */
     virtual ~LMPC() = default; 
     
-    LMPC(const LMPC&) = default;
     LMPC(LMPC&&) = default;
-    LMPC& operator=(const LMPC&) = default;
     LMPC& operator=(LMPC&&) = default;
 
     /**

--- a/include/LMPC.h
+++ b/include/LMPC.h
@@ -45,10 +45,20 @@ public:
     /**
      * Initialize problem variables w.r.t. the PreviewSystem and get the desired
      * solver
-     * \param ps A preview system to amke a copy from.
+     * \param ps A preview system to make a copy from.
      * \param sFlag The flag corresponding to the desired solver.
      */
     LMPC(const std::shared_ptr<PreviewSystem>& ps, SolverFlag sFlag = SolverFlag::DEFAULT);
+
+    /**
+     * Virtual destructor
+     */
+    virtual ~LMPC() = default; 
+    
+    LMPC(const LMPC&) = default;
+    LMPC(LMPC&&) = default;
+    LMPC& operator=(const LMPC&) = default;
+    LMPC& operator=(LMPC&&) = default;
 
     /**
      * Select a solver. It will load a solver with default values.
@@ -68,7 +78,7 @@ public:
      * This function needs to be called each time the system dimension changes.
      * \param ps The preview system
      */
-    void initializeController(const std::shared_ptr<PreviewSystem>& ps);
+    virtual void initializeController(const std::shared_ptr<PreviewSystem>& ps);
 
     /**
      * Solve the system.
@@ -76,7 +86,7 @@ public:
      * Fill Phi, Psi, xi in PreviewSystem
      * Fill A, b in Constraints
      */
-    bool solve();
+    virtual bool solve();
 
     /**
      * Print information on the QP solver status.
@@ -92,12 +102,12 @@ public:
      * Get the solver result.
      * \return The control vector \f$U\f$.
      */
-    const Eigen::VectorXd& control() const noexcept;
+    virtual const Eigen::VectorXd& control() const noexcept;
     /**
      * Get the preview trajectory.
      * \return The trajectory vector \f$X\f$.
      */
-    Eigen::VectorXd trajectory() const noexcept;
+    virtual Eigen::VectorXd trajectory() const noexcept;
     /**
      * The time needed to solve the qp problem.
      * \return The elapsed time (in s) for solving.
@@ -143,14 +153,14 @@ public:
      */
     inline int get_nrEqConstr() { return constraints_.nrEqConstr; }
     inline int get_nrIneqConstr() { return constraints_.nrIneqConstr; }
-    inline Eigen::MatrixXd& get_Q() { return Q_; }
-    inline Eigen::MatrixXd& get_Aineq() { return Aineq_; }
-    inline Eigen::MatrixXd& get_Aeq() { return Aeq_; }
-    inline Eigen::VectorXd& get_c() { return c_; }
-    inline Eigen::VectorXd& get_bineq() { return bineq_; }
-    inline Eigen::VectorXd& get_beq() { return beq_; }
-    inline Eigen::VectorXd& get_lb() { return lb_; }
-    inline Eigen::VectorXd& get_ub() { return ub_; }
+    inline Eigen::MatrixXd get_Q() { return Q_; }
+    inline Eigen::MatrixXd get_Aineq() { return Aineq_; }
+    inline Eigen::MatrixXd get_Aeq() { return Aeq_; }
+    inline Eigen::VectorXd get_c() { return c_; }
+    inline Eigen::VectorXd get_bineq() { return bineq_; }
+    inline Eigen::VectorXd get_beq() { return beq_; }
+    inline Eigen::VectorXd get_lb() { return lb_; }
+    inline Eigen::VectorXd get_ub() { return ub_; }
 
 protected:
     /**
@@ -162,18 +172,18 @@ protected:
     /**
      * Resize Aeq, beq, Aineq, bineq, ub, lb to default.
      */
-    void clearConstraintMatrices();
+    virtual void clearConstraintMatrices();
 
     /**
      * Update the system and its constraints.
      * Fill A, b in Constraints
      */
-    void updateSystem();
+    virtual void updateSystem();
 
     /**
      * QP-like format.
      */
-    void makeQPForm();
+    virtual void makeQPForm();
 
     /**
      * Check if a cost or a constraint still exist.

--- a/include/LMPC.h
+++ b/include/LMPC.h
@@ -138,6 +138,20 @@ public:
      */
     void removeConstraint(const std::shared_ptr<Constraint>& constr);
 
+    /**
+     * Getter Functions
+     */
+    inline int get_nrEqConstr() { return constraints_.nrEqConstr; }
+    inline int get_nrIneqConstr() { return constraints_.nrIneqConstr; }
+    inline Eigen::MatrixXd& get_Q() { return Q_; }
+    inline Eigen::MatrixXd& get_Aineq() { return Aineq_; }
+    inline Eigen::MatrixXd& get_Aeq() { return Aeq_; }
+    inline Eigen::VectorXd& get_c() { return c_; }
+    inline Eigen::VectorXd& get_bineq() { return bineq_; }
+    inline Eigen::VectorXd& get_beq() { return beq_; }
+    inline Eigen::VectorXd& get_lb() { return lb_; }
+    inline Eigen::VectorXd& get_ub() { return ub_; }
+
 protected:
     /**
      * Add constraints into constraints_ \see Constraints

--- a/include/LMPC.h
+++ b/include/LMPC.h
@@ -138,7 +138,7 @@ public:
      */
     void removeConstraint(const std::shared_ptr<Constraint>& constr);
 
-public: //protected:
+protected:
     /**
      * Add constraints into constraints_ \see Constraints
      * \param constr The constraint to add
@@ -168,7 +168,7 @@ public: //protected:
      */
     void checkDeleteCostsAndConstraints();
 
-public: //protected:
+protected:
     struct Constraints {
         Constraints();
         void clear();
@@ -182,7 +182,7 @@ public: //protected:
         std::vector<std::shared_ptr<ControlBoundConstraint>> spBoundConstr;
     };
 
-public: //protected:
+protected:
     std::shared_ptr<PreviewSystem> ps_;
     std::unique_ptr<SolverInterface> sol_;
     std::vector<std::shared_ptr<CostFunction>> spCost_;

--- a/include/LMPC.h
+++ b/include/LMPC.h
@@ -138,7 +138,7 @@ public:
      */
     void removeConstraint(const std::shared_ptr<Constraint>& constr);
 
-protected:
+public: //protected:
     /**
      * Add constraints into constraints_ \see Constraints
      * \param constr The constraint to add
@@ -168,7 +168,7 @@ protected:
      */
     void checkDeleteCostsAndConstraints();
 
-protected:
+public: //protected:
     struct Constraints {
         Constraints();
         void clear();
@@ -182,7 +182,7 @@ protected:
         std::vector<std::shared_ptr<ControlBoundConstraint>> spBoundConstr;
     };
 
-protected:
+public: //protected:
     std::shared_ptr<PreviewSystem> ps_;
     std::unique_ptr<SolverInterface> sol_;
     std::vector<std::shared_ptr<CostFunction>> spCost_;

--- a/include/PreviewSystem.h
+++ b/include/PreviewSystem.h
@@ -61,6 +61,11 @@ struct COPRA_DLLAPI PreviewSystem {
      */
     void xInit(const Eigen::VectorXd& xInit) { x0 = xInit; }
 
+    /**
+     * \brief Get the initial state.
+     */
+    Eigen::VectorXd& xInit() { return x0; }
+
     bool isUpdated = false; /**< State whether or not the preview system has been updated. This is done when calling the solve function of a mpc. Calling \see system or setting this to false will force a new update*/
     int nrUStep = 0; /**< The number of iteration to perform for U (it is the dimension of \f$U\f$, \f$N\f$). */
     int nrXStep = 0; /**< The number of iteration to perform for X (it is the dimension of \f$X\f$, \f$N+1\f$). */

--- a/include/constraints.h
+++ b/include/constraints.h
@@ -137,7 +137,7 @@ public:
      */
     const Eigen::VectorXd& z() const noexcept { return z_; }
 
-public: //protected:
+protected:
     Eigen::MatrixXd A_;
     Eigen::VectorXd b_;
     Eigen::MatrixXd Y_;

--- a/include/constraints.h
+++ b/include/constraints.h
@@ -125,9 +125,23 @@ public:
      */
     const Eigen::VectorXd& b() const noexcept { return b_; }
 
-protected:
+    /**
+     * Get the 'Y' matrix of the Equality/Inequality (\f$Ax\leq b\f$, \f$Ax = b\f$)
+     * \return The 'Y' matrix of the constraint
+     */
+    const Eigen::MatrixXd& Y() const noexcept { return Y_; }
+
+    /**
+     * Get the 'z' vector of the Equality/Inequality (\f$Ax\leq b\f$, \f$Ax = b\f$)
+     * \return The 'z' vector of the constraint
+     */
+    const Eigen::VectorXd& z() const noexcept { return z_; }
+
+public: //protected:
     Eigen::MatrixXd A_;
     Eigen::VectorXd b_;
+    Eigen::MatrixXd Y_;
+    Eigen::VectorXd z_;
     bool isIneq_;
 };
 

--- a/include/costFunctions.h
+++ b/include/costFunctions.h
@@ -101,11 +101,27 @@ public:
      */
     const Eigen::VectorXd& c() const noexcept { return c_; }
 
+    /**
+     * \brief Function that return the E matrix of the cost function
+     * A cost function is written \f$ \frac{1}{2} x^T Q x + c^T x\f$.
+     * \return The Q matrix
+     */
+    const Eigen::MatrixXd& E() const noexcept { return E_; }
+
+    /**
+     * \brief Function that return the f vector of the cost function
+     * A cost function is written \f$ \frac{1}{2} x^T Q x + c^T x\f$.
+     * \return The c vector matrix
+     */
+    const Eigen::VectorXd& f() const noexcept { return f_; }
+
 protected:
     std::string name_;
     bool fullSizeEntry_;
     Eigen::MatrixXd Q_;
     Eigen::VectorXd c_;
+    Eigen::MatrixXd E_;
+    Eigen::VectorXd f_;
     Eigen::VectorXd weights_;
 };
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     constraints.cpp
     debugUtils.cpp
     LMPC.cpp
+    InitialStateLMPC.cpp
     solverUtils.cpp
 )
 
@@ -24,6 +25,7 @@ set(HEADERS
     ../include/constraints.h
     ../include/debugUtils.h
     ../include/LMPC.h 
+    ../include/InitialStateLMPC.h 
     ../include/solverUtils.h 
     ../include/typedefs.h
 )

--- a/src/InitialStateLMPC.cpp
+++ b/src/InitialStateLMPC.cpp
@@ -129,15 +129,15 @@ Eigen::VectorXd InitialStateLMPC::trajectory() const noexcept
 
 void InitialStateLMPC::resetInitialStateCost(const Eigen::MatrixXd& R, const Eigen::VectorXd& r)
 {
-    //assert matrix R is positive definite
-    //assert correct sizes
+    assert(R_.cols() == R.cols() && R_.rows() == R.rows() && "Matrix size mismatch");
+    //R must be positive definite!
     R_ = R;
     r_ = r;
 }
 
 void InitialStateLMPC::resetInitialStateBounds(const Eigen::VectorXd& l, const Eigen::VectorXd& u)
 {
-    //assert correct sizes
+    assert(l.rows() == ps_->xDim && u.rows() == ps_->xDim && "Vector size mismatch");
     l_ = l;
     u_ = u;
 }

--- a/src/InitialStateLMPC.cpp
+++ b/src/InitialStateLMPC.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2016-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#include "InitialStateLMPC.h"
+#include "constraints.h"
+#include "costFunctions.h"
+
+namespace copra {
+
+
+/*************************************************************************************************
+ *                                             InitialStateLMPC                                               *
+ *************************************************************************************************/
+InitialStateLMPC::InitialStateLMPC(SolverFlag sFlag)
+    : LMPC(sFlag), 
+    R_(), 
+    r_(),
+    E_(), 
+    f_(),
+    l_(),
+    u_(),
+    Yeq_(),
+    zeq_(),
+    Yineq_(),
+    zineq_(),
+    newQ_(), 
+    newc_(), 
+    newlb_(), 
+    newub_(),
+    newAeq_(),
+    newbeq_(),
+    newAineq_(),
+    newbineq_()
+{
+}
+
+InitialStateLMPC::InitialStateLMPC(const std::shared_ptr<PreviewSystem>& ps, SolverFlag sFlag)
+    : LMPC(ps, sFlag), 
+    R_(ps_->xDim,ps_->xDim), 
+    r_(ps_->xDim),
+    E_(ps_->xDim, ps_->fullUDim), 
+    f_(ps_->fullUDim),
+    l_(ps_->xDim),
+    u_(ps_->xDim),
+    Yeq_(),
+    zeq_(),
+    Yineq_(),
+    zineq_(),
+    newQ_(ps_->xDim+ps_->fullUDim, ps_->xDim+ps_->fullUDim), 
+    newc_(ps_->xDim+ps_->fullUDim), 
+    newlb_(ps_->xDim+ps_->fullUDim), 
+    newub_(ps_->xDim+ps_->fullUDim),
+    newAeq_(),
+    newbeq_(),
+    newAineq_(),
+    newbineq_()
+{
+    l_.setConstant(-std::numeric_limits<double>::max());
+    u_.setConstant(std::numeric_limits<double>::max());
+    newlb_.setConstant(-std::numeric_limits<double>::max());
+    newub_.setConstant(std::numeric_limits<double>::max());
+}
+
+
+void InitialStateLMPC::initializeController(const std::shared_ptr<PreviewSystem>& ps)
+{
+    LMPC::initializeController(ps);
+
+    newQ_.resize(ps_->xDim+ps_->fullUDim, ps_->xDim+ps_->fullUDim);
+    newc_.resize(ps_->xDim+ps_->fullUDim);
+}
+
+bool InitialStateLMPC::solve()
+{
+    //don't call the function solve() of the base-class!
+
+    using namespace std::chrono;
+    auto sabTime = high_resolution_clock::now();
+
+    updateSystem();
+    // TODO: Need to be rewrite to minimize building time accross the solvers.
+    // It will be better to directly build all matrices in the solvers.
+    makeQPForm();
+    sol_->SI_problem(ps_->xDim+ps_->fullUDim, constraints_.nrEqConstr, constraints_.nrIneqConstr);
+
+    auto sTime = high_resolution_clock::now();
+    bool success = sol_->SI_solve(newQ_, newc_, newAeq_, newbeq_, newAineq_, newbineq_, newlb_, newub_);
+    solveTime_ = duration_cast<duration<double>>(high_resolution_clock::now() - sTime);
+
+    checkDeleteCostsAndConstraints();
+
+    solveAndBuildTime_ = duration_cast<duration<double>>(high_resolution_clock::now() - sabTime);
+    return success;
+}
+
+Eigen::VectorXd InitialStateLMPC::initialState() const noexcept
+{
+    return sol_->SI_result().tail(ps_->xDim);
+}
+
+Eigen::VectorXd InitialStateLMPC::control() const noexcept
+{
+    return sol_->SI_result().tail(ps_->fullUDim);
+}
+
+Eigen::VectorXd InitialStateLMPC::trajectory() const noexcept
+{
+    return ps_->Phi * initialState() + ps_->Psi * control() + ps_->xi;
+}
+
+void InitialStateLMPC::resetInitialStateCost(const Eigen::MatrixXd& R, const Eigen::VectorXd& r)
+{
+    //assert matrix R is positive definite
+    //assert correct sizes
+    R_ = R;
+    r_ = r;
+}
+
+void InitialStateLMPC::resetInitialStateBounds(const Eigen::VectorXd& l, const Eigen::VectorXd& u)
+{
+    //assert correct sizes
+    l_ = l;
+    u_ = u;
+}
+
+/*
+ *  Protected methods
+ */
+
+void InitialStateLMPC::clearConstraintMatrices()
+{
+    LMPC::clearConstraintMatrices();
+
+    Yineq_.resize(0, ps_->xDim);
+    Yeq_.resize(0, ps_->xDim);
+    zineq_.resize(0);
+    zeq_.resize(0);
+    l_.resize(ps_->xDim);
+    u_.resize(ps_->xDim);
+    l_.setConstant(-std::numeric_limits<double>::max());
+    u_.setConstant(std::numeric_limits<double>::max());
+    newAineq_.resize(0, ps_->xDim+ps_->fullUDim);
+    newAeq_.resize(0, ps_->xDim+ps_->fullUDim);
+    newbineq_.resize(0);
+    newbeq_.resize(0);
+    newlb_.resize(ps_->xDim+ps_->fullUDim);
+    newub_.resize(ps_->xDim+ps_->fullUDim);
+    newlb_.setConstant(-std::numeric_limits<double>::max());
+    newub_.setConstant(std::numeric_limits<double>::max());
+}
+
+void InitialStateLMPC::updateSystem()
+{
+    LMPC::updateSystem();
+
+    E_.setZero();
+    f_.setZero();
+    R_.setIdentity();
+    R_ *= 1e-6; // Ensure that R is positive definite if no cost functions are used
+    r_.setZero();
+    newQ_.setIdentity();
+    newQ_ *= 1e-6; // Ensure that newQ is positive definite if no cost functions are used
+    newc_.setZero();
+    Yeq_.resize(constraints_.nrEqConstr, ps_->xDim);
+    zeq_.resize(constraints_.nrEqConstr);
+    Yineq_.resize(constraints_.nrIneqConstr, ps_->xDim);
+    zineq_.resize(constraints_.nrIneqConstr);
+    newAeq_.resize(constraints_.nrEqConstr, ps_->xDim+ps_->fullUDim);
+    newbeq_.resize(constraints_.nrEqConstr);
+    newAineq_.resize(constraints_.nrIneqConstr, ps_->xDim+ps_->fullUDim);
+    newbineq_.resize(constraints_.nrIneqConstr);
+}
+
+void InitialStateLMPC::makeQPForm()
+{
+    //don't call the function makeQPForm() of the base-class!
+
+    for (auto& cost : spCost_) {
+        Q_ += cost->Q();
+        // c_ += cost->c(); //not required!
+        E_ += cost->E();
+        f_ += cost->f();
+    }
+
+    int nrLines;
+    // Get Equality constraints
+    nrLines = 0;
+    for (auto& cstr : constraints_.spEqConstr) {
+        Aeq_.block(nrLines, 0, cstr->nrConstr(), ps_->fullUDim) = cstr->A();
+        // beq_.segment(nrLines, cstr->nrConstr()) = cstr->b(); //not required!
+        Yeq_.block(nrLines, 0, cstr->nrConstr(), ps_->xDim) = cstr->Y();
+        zeq_.segment(nrLines, cstr->nrConstr()) = cstr->z();
+        nrLines += cstr->nrConstr();
+    }
+    // Get Inequality constraints
+    nrLines = 0;
+    for (auto& cstr : constraints_.spIneqConstr) {
+        Aineq_.block(nrLines, 0, cstr->nrConstr(), ps_->fullUDim) = cstr->A();
+        // bineq_.segment(nrLines, cstr->nrConstr()) = cstr->b(); //not required!
+        Yineq_.block(nrLines, 0, cstr->nrConstr(), ps_->xDim) = cstr->Y();
+        zineq_.segment(nrLines, cstr->nrConstr()) = cstr->z();
+        nrLines += cstr->nrConstr();
+    }
+    // Get Bound constraints
+    nrLines = 0;
+    for (auto& cstr : constraints_.spBoundConstr) {
+        lb_.segment(nrLines, cstr->nrConstr()) = cstr->lower();
+        ub_.segment(nrLines, cstr->nrConstr()) = cstr->upper();
+        nrLines += cstr->nrConstr();
+    }
+
+    // prepare the new QP format
+    newQ_.topLeftCorner(ps_->xDim,ps_->xDim) = R_ + E_ * Q_.inverse() * E_.transpose(); //TODO we may want to use another method to compute the inverse of Q
+    newQ_.topRightCorner(ps_->xDim,ps_->fullUDim) = E_;
+    newQ_.bottomLeftCorner(ps_->fullUDim,ps_->xDim) = E_.transpose();
+    newQ_.bottomRightCorner(ps_->fullUDim,ps_->fullUDim) = Q_;
+    newc_.head(ps_->xDim) = r_;
+    newc_.tail(ps_->fullUDim) = f_;
+
+    newAeq_.leftCols(ps_->xDim) = Yeq_;
+    newAeq_.rightCols(ps_->fullUDim) = Aeq_;
+    newbeq_ = zeq_;
+
+    newAineq_.leftCols(ps_->xDim) = Yineq_;
+    newAineq_.rightCols(ps_->fullUDim) = Aineq_;
+    newbineq_ = zineq_;
+
+    newlb_.head(ps_->xDim) = l_;
+    newub_.head(ps_->xDim) = u_;
+    newlb_.tail(ps_->fullUDim) = lb_;
+    newub_.tail(ps_->fullUDim) = ub_;
+}
+
+} // namespace copra

--- a/src/constraints.cpp
+++ b/src/constraints.cpp
@@ -29,6 +29,8 @@ EqIneqConstraint::EqIneqConstraint(const std::string& constrQualifier, bool isIn
     : Constraint(constrQualifier + (isInequalityConstraint ? " inequality constraint" : " equality constraint"))
     , A_()
     , b_()
+    , Y_()
+    , z_()
     , isIneq_(isInequalityConstraint)
 {
 }
@@ -61,6 +63,8 @@ void TrajectoryConstraint::initializeConstraint(const PreviewSystem& ps)
 
     A_.resize(nrConstr_, ps.fullUDim);
     b_.resize(nrConstr_);
+    Y_.resize(nrConstr_, ps.xDim);
+    z_.resize(nrConstr_);
 }
 
 void TrajectoryConstraint::update(const PreviewSystem& ps)
@@ -68,11 +72,15 @@ void TrajectoryConstraint::update(const PreviewSystem& ps)
     if (fullSizeEntry_) {
         A_.noalias() = E_ * ps.Psi;
         b_.noalias() = f_ - E_ * (ps.Phi * ps.x0 + ps.xi);
+        Y_.noalias() = E_ * ps.Phi;
+        z_.noalias() = f_ - E_ * ps.xi;
     } else {
         auto nrLines = static_cast<int>(E_.rows());
         for (int i = 0; i < ps.nrXStep; ++i) {
             A_.block(i * nrLines, 0, nrLines, ps.fullUDim).noalias() = E_ * ps.Psi.block(i * ps.xDim, 0, ps.xDim, ps.fullUDim);
             b_.segment(i * nrLines, nrLines).noalias() = f_ - E_ * (ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim) * ps.x0 + ps.xi.segment(i * ps.xDim, ps.xDim));
+            Y_.block(i * nrLines, 0, nrLines, ps.xDim).noalias() = E_ * ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim);
+            z_.segment(i * nrLines, nrLines).noalias() = f_ - E_ * ps.xi.segment(i * ps.xDim, ps.xDim);
         }
     }
 }
@@ -117,6 +125,10 @@ void ControlConstraint::initializeConstraint(const PreviewSystem& ps)
     } else {
         DOMAIN_ERROR_EXCEPTION(throwMsgOnColsOnPSUDim("G", G_, &ps));
     }
+    Y_.resize(nrConstr_, ps.xDim);//TODO number of rows may be =0 or = ps.xDim
+    z_.resize(nrConstr_);//TODO number of rows may be =0 or = ps.xDim
+    Y_.setZero();
+    z_ = b_;
 
     hasBeenInitialized_ = true;
 }
@@ -129,6 +141,8 @@ void ControlConstraint::update(const PreviewSystem& ps)
             A_.block(i * nrLines, i * ps.uDim, nrLines, ps.uDim) = G_;
             b_.segment(i * nrLines, nrLines) = f_;
         }
+        Y_.setZero();
+        z_ = b_;
     }
 }
 
@@ -170,7 +184,10 @@ void MixedConstraint::initializeConstraint(const PreviewSystem& ps)
 
     A_.resize(nrConstr_, ps.fullUDim);
     b_.resize(nrConstr_);
+    Y_.resize(nrConstr_, ps.xDim);
+    z_.resize(nrConstr_);
     A_.setZero();
+    Y_.setZero();
 }
 
 void MixedConstraint::update(const PreviewSystem& ps)
@@ -178,18 +195,24 @@ void MixedConstraint::update(const PreviewSystem& ps)
     if (fullSizeEntry_) {
         A_.noalias() = E_ * ps.Psi + G_;
         b_.noalias() = f_ - E_ * (ps.Phi * ps.x0 + ps.xi);
+        Y_.noalias() = E_ * ps.Phi;
+        z_.noalias() = f_ - E_ * ps.xi;
     } else {
         auto nrLines = static_cast<int>(E_.rows());
         auto uDim = ps.uDim;
         auto xDim = ps.xDim;
         A_.block(0, 0, nrLines, uDim) = G_;
         b_.head(nrLines) = f_ - E_ * ps.x0;
+        Y_.block(0, 0, nrLines, xDim) = E_;
+        z_.head(nrLines) = f_;
         for (int i = 1; i < ps.nrUStep; ++i) {
             A_.block(i * nrLines, 0, nrLines, uDim) = E_ * ps.Psi.block(i * xDim, 0, xDim, uDim);
+            Y_.block(i * nrLines, 0, nrLines, xDim) = E_ * ps.Phi.block(i * xDim, 0, xDim, xDim);//TODO check dimensions
             for (int j = 1; j <= i; ++j)
                 A_.block(i * nrLines, j * uDim, nrLines, uDim) = A_.block((i - 1) * nrLines, (j - 1) * uDim, nrLines, uDim);
 
             b_.segment(i * nrLines, nrLines) = f_ - E_ * (ps.Phi.block(i * xDim, 0, xDim, xDim) * ps.x0 + ps.xi.segment(i * xDim, xDim));
+            z_.segment(i * nrLines, nrLines) = f_ - E_ * ps.xi.segment(i * xDim, xDim);
         }
     }
 }
@@ -243,10 +266,13 @@ void TrajectoryBoundConstraint::initializeConstraint(const PreviewSystem& ps)
 
     A_.resize(nrConstr_, ps.fullUDim);
     b_.resize(nrConstr_);
+    Y_.resize(nrConstr_, ps.xDim);
+    z_.resize(nrConstr_);
 }
 
 void TrajectoryBoundConstraint::update(const PreviewSystem& ps)
 {
+    //TODO compute also Y and z
     int nrLines = 0;
     Eigen::VectorXd delta = ps.Phi * ps.x0 + ps.xi;
     for (auto step = 0; step < ps.nrXStep; ++step) {

--- a/src/constraints.cpp
+++ b/src/constraints.cpp
@@ -298,7 +298,7 @@ void TrajectoryBoundConstraint::update(const PreviewSystem& ps)
             // b_(nrLines) = upper_(line) - delta(line + ps.xDim * step);
             Y_.row(nrLines) = ps.Phi.row(line + ps.xDim * step);
             z_(nrLines) = upper_(line) - ps.xi(line + ps.xDim * step);
-            b_(nrLines) = upper_(line) - Y_.row(nrLines) * ps.x0;
+            b_(nrLines) = z_(nrLines) - Y_.row(nrLines) * ps.x0;
             ++nrLines;
         }
         if (fullSizeEntry_)

--- a/src/costFunctions.cpp
+++ b/src/costFunctions.cpp
@@ -147,7 +147,7 @@ void ControlCost::update(const PreviewSystem& ps)
         for (int i = 0; i < ps.nrUStep; ++i) {
             Q_.block(i * ps.uDim, i * ps.uDim, ps.uDim, ps.uDim) = mat;
             // c_.segment(i * ps.uDim, ps.uDim) = vec;
-            E_.block(i * ps.uDim, i * ps.uDim, ps.uDim, ps.uDim).setZero();
+            E_.block(0, i * ps.uDim, ps.xDim, ps.uDim).setZero();
             f_.segment(i * ps.uDim, ps.uDim) = vec;
             c_.segment(i * ps.uDim, ps.uDim) = f_.segment(i * ps.uDim, ps.uDim);
         }

--- a/src/costFunctions.cpp
+++ b/src/costFunctions.cpp
@@ -75,8 +75,8 @@ void TrajectoryCost::update(const PreviewSystem& ps)
             // c_.noalias() += (M_ * (ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim) * ps.x0 + ps.xi.segment(i * ps.xDim, ps.xDim)) - p_).transpose() * weights_.asDiagonal() * tmp;
             E_.noalias() += (M_ * ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim)).transpose() * weights_.asDiagonal() * tmp;
             f_.noalias() += (M_ * ps.xi.segment(i * ps.xDim, ps.xDim) - p_).transpose() * weights_.asDiagonal() * tmp;
-            c_.noalias() += E_.transpose() * ps.x0 + f_;
         }
+        c_.noalias() = E_.transpose() * ps.x0 + f_;
     }
 }
 
@@ -204,8 +204,8 @@ void MixedCost::update(const PreviewSystem& ps)
             // c_.noalias() += (M_ * (ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim) * ps.x0 + ps.xi.segment(i * ps.xDim, ps.xDim)) - p_).transpose() * weights_.asDiagonal() * tmp;
             E_.noalias() += (M_ * ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim)).transpose() * weights_.asDiagonal() * tmp;
             f_.noalias() += (M_ * ps.xi.segment(i * ps.xDim, ps.xDim) - p_).transpose() * weights_.asDiagonal() * tmp;
-            c_.noalias() += E_.transpose() * ps.x0 + f_;
         }
+        c_.noalias() += E_.transpose() * ps.x0 + f_;
     }
 }
 

--- a/src/costFunctions.cpp
+++ b/src/costFunctions.cpp
@@ -25,6 +25,8 @@ void CostFunction::initializeCost(const PreviewSystem& ps)
 {
     Q_.resize(ps.fullUDim, ps.fullUDim);
     c_.resize(ps.fullUDim);
+    E_.resize(ps.xDim, ps.fullUDim);
+    f_.resize(ps.fullUDim);
 }
 
 /*************************************************************************************************
@@ -48,6 +50,8 @@ void TrajectoryCost::initializeCost(const PreviewSystem& ps)
     if (M_.cols() == ps.xDim) {
         Q_.setZero();
         c_.setZero();
+        E_.setZero();
+        f_.setZero();
     } else if (M_.cols() == ps.fullXDim) {
         fullSizeEntry_ = true;
     } else {
@@ -61,11 +65,15 @@ void TrajectoryCost::update(const PreviewSystem& ps)
         Eigen::MatrixXd tmp{ M_ * ps.Psi };
         Q_ = tmp.transpose() * weights_.asDiagonal() * tmp;
         c_ = (M_ * (ps.Phi * ps.x0 + ps.xi) - p_).transpose() * weights_.asDiagonal() * tmp;
+        E_ = (M_ * ps.Phi).transpose() * weights_.asDiagonal() * tmp;
+        f_ = (M_ * ps.xi - p_).transpose() * weights_.asDiagonal() * tmp;
     } else {
         for (int i = 0; i < ps.nrXStep; ++i) { // Can be optimized. Lot of sums of zero here
             Eigen::MatrixXd tmp{ M_ * ps.Psi.block(i * ps.xDim, 0, ps.xDim, ps.fullUDim) };
             Q_.noalias() += tmp.transpose() * weights_.asDiagonal() * tmp;
             c_.noalias() += (M_ * (ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim) * ps.x0 + ps.xi.segment(i * ps.xDim, ps.xDim)) - p_).transpose() * weights_.asDiagonal() * tmp;
+            E_.noalias() += (M_ * ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim)).transpose() * weights_.asDiagonal() * tmp;
+            f_.noalias() += (M_ * ps.xi.segment(i * ps.xDim, ps.xDim) - p_).transpose() * weights_.asDiagonal() * tmp;
         }
     }
 }
@@ -89,6 +97,8 @@ void TargetCost::update(const PreviewSystem& ps)
     Eigen::MatrixXd tmp{ M_ * ps.Psi.bottomRows(ps.xDim) };
     Q_.noalias() = tmp.transpose() * weights_.asDiagonal() * tmp;
     c_.noalias() = (M_ * (ps.Phi.bottomRows(ps.xDim) * ps.x0 + ps.xi.bottomRows(ps.xDim)) - p_).transpose() * weights_.asDiagonal() * tmp;
+    E_.noalias() = (M_ * ps.Phi.bottomRows(ps.xDim)).transpose() * weights_.asDiagonal() * tmp;
+    f_.noalias() = (M_ * ps.xi.bottomRows(ps.xDim) - p_).transpose() * weights_.asDiagonal() * tmp;
 }
 
 /*************************************************************************************************
@@ -110,7 +120,10 @@ void ControlCost::initializeCost(const PreviewSystem& ps)
         DOMAIN_ERROR_EXCEPTION(throwMsgOnRowsAskAutoSpan("N", "p", N_, p_));
 
     if (N_.cols() == ps.uDim)
+    {
         Q_.setZero();
+        E_.setZero();
+    }
     else if (N_.cols() == ps.fullUDim)
         fullSizeEntry_ = true;
     else
@@ -122,12 +135,16 @@ void ControlCost::update(const PreviewSystem& ps)
     if (fullSizeEntry_) {
         Q_.noalias() = N_.transpose() * weights_.asDiagonal() * N_;
         c_.noalias() = -p_.transpose() * weights_.asDiagonal() * N_;
+        E_.setZero();
+        f_.noalias() = -p_.transpose() * weights_.asDiagonal() * N_;
     } else {
         Eigen::MatrixXd mat{ N_.transpose() * weights_.asDiagonal() * N_ };
         Eigen::VectorXd vec{ -p_.transpose() * weights_.asDiagonal() * N_ };
         for (int i = 0; i < ps.nrUStep; ++i) {
             Q_.block(i * ps.uDim, i * ps.uDim, ps.uDim, ps.uDim) = mat;
             c_.segment(i * ps.uDim, ps.uDim) = vec;
+            E_.block(i * ps.uDim, i * ps.uDim, ps.uDim, ps.uDim).setZero();
+            f_.segment(i * ps.uDim, ps.uDim) = vec;
         }
     }
 }
@@ -156,6 +173,8 @@ void MixedCost::initializeCost(const PreviewSystem& ps)
     if (M_.cols() == ps.xDim && N_.cols() == ps.uDim) {
         Q_.setZero();
         c_.setZero();
+        E_.setZero();
+        f_.setZero();
     } else if (M_.cols() == ps.fullXDim && N_.cols() == ps.fullUDim) {
         fullSizeEntry_ = true;
     } else {
@@ -169,12 +188,16 @@ void MixedCost::update(const PreviewSystem& ps)
         Eigen::MatrixXd tmp = M_ * ps.Psi + N_;
         Q_.noalias() = tmp.transpose() * weights_.asDiagonal() * tmp;
         c_.noalias() = (M_ * (ps.Phi * ps.x0 + ps.xi) - p_).transpose() * weights_.asDiagonal() * tmp;
+        E_.noalias() = (M_ * ps.Phi).transpose() * weights_.asDiagonal() * tmp;
+        f_.noalias() = (M_ * ps.xi - p_).transpose() * weights_.asDiagonal() * tmp;
     } else {
         for (int i = 0; i < ps.nrUStep; ++i) { // Can be optimized. Lot of sums of zero here
             Eigen::MatrixXd tmp{ M_ * ps.Psi.block(i * ps.xDim, 0, ps.xDim, ps.fullUDim) };
             tmp.block(0, i * ps.uDim, M_.rows(), ps.uDim).noalias() += N_;
             Q_.noalias() += tmp.transpose() * weights_.asDiagonal() * tmp;
             c_.noalias() += (M_ * (ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim) * ps.x0 + ps.xi.segment(i * ps.xDim, ps.xDim)) - p_).transpose() * weights_.asDiagonal() * tmp;
+            E_.noalias() += (M_ * ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim)).transpose() * weights_.asDiagonal() * tmp;
+            f_.noalias() += (M_ * ps.xi.segment(i * ps.xDim, ps.xDim) - p_).transpose() * weights_.asDiagonal() * tmp;
         }
     }
 }

--- a/src/costFunctions.cpp
+++ b/src/costFunctions.cpp
@@ -64,16 +64,18 @@ void TrajectoryCost::update(const PreviewSystem& ps)
     if (fullSizeEntry_) {
         Eigen::MatrixXd tmp{ M_ * ps.Psi };
         Q_ = tmp.transpose() * weights_.asDiagonal() * tmp;
-        c_ = (M_ * (ps.Phi * ps.x0 + ps.xi) - p_).transpose() * weights_.asDiagonal() * tmp;
+        // c_ = (M_ * (ps.Phi * ps.x0 + ps.xi) - p_).transpose() * weights_.asDiagonal() * tmp;
         E_ = (M_ * ps.Phi).transpose() * weights_.asDiagonal() * tmp;
         f_ = (M_ * ps.xi - p_).transpose() * weights_.asDiagonal() * tmp;
+        c_ = E_.transpose() * ps.x0 + f_;
     } else {
         for (int i = 0; i < ps.nrXStep; ++i) { // Can be optimized. Lot of sums of zero here
             Eigen::MatrixXd tmp{ M_ * ps.Psi.block(i * ps.xDim, 0, ps.xDim, ps.fullUDim) };
             Q_.noalias() += tmp.transpose() * weights_.asDiagonal() * tmp;
-            c_.noalias() += (M_ * (ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim) * ps.x0 + ps.xi.segment(i * ps.xDim, ps.xDim)) - p_).transpose() * weights_.asDiagonal() * tmp;
+            // c_.noalias() += (M_ * (ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim) * ps.x0 + ps.xi.segment(i * ps.xDim, ps.xDim)) - p_).transpose() * weights_.asDiagonal() * tmp;
             E_.noalias() += (M_ * ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim)).transpose() * weights_.asDiagonal() * tmp;
             f_.noalias() += (M_ * ps.xi.segment(i * ps.xDim, ps.xDim) - p_).transpose() * weights_.asDiagonal() * tmp;
+            c_.noalias() += E_.transpose() * ps.x0 + f_;
         }
     }
 }
@@ -96,9 +98,10 @@ void TargetCost::update(const PreviewSystem& ps)
 {
     Eigen::MatrixXd tmp{ M_ * ps.Psi.bottomRows(ps.xDim) };
     Q_.noalias() = tmp.transpose() * weights_.asDiagonal() * tmp;
-    c_.noalias() = (M_ * (ps.Phi.bottomRows(ps.xDim) * ps.x0 + ps.xi.bottomRows(ps.xDim)) - p_).transpose() * weights_.asDiagonal() * tmp;
+    // c_.noalias() = (M_ * (ps.Phi.bottomRows(ps.xDim) * ps.x0 + ps.xi.bottomRows(ps.xDim)) - p_).transpose() * weights_.asDiagonal() * tmp;
     E_.noalias() = (M_ * ps.Phi.bottomRows(ps.xDim)).transpose() * weights_.asDiagonal() * tmp;
     f_.noalias() = (M_ * ps.xi.bottomRows(ps.xDim) - p_).transpose() * weights_.asDiagonal() * tmp;
+    c_.noalias() = E_.transpose() * ps.x0 + f_;
 }
 
 /*************************************************************************************************
@@ -134,17 +137,19 @@ void ControlCost::update(const PreviewSystem& ps)
 {
     if (fullSizeEntry_) {
         Q_.noalias() = N_.transpose() * weights_.asDiagonal() * N_;
-        c_.noalias() = -p_.transpose() * weights_.asDiagonal() * N_;
+        // c_.noalias() = -p_.transpose() * weights_.asDiagonal() * N_;
         E_.setZero();
         f_.noalias() = -p_.transpose() * weights_.asDiagonal() * N_;
+        c_.noalias() = f_;
     } else {
         Eigen::MatrixXd mat{ N_.transpose() * weights_.asDiagonal() * N_ };
         Eigen::VectorXd vec{ -p_.transpose() * weights_.asDiagonal() * N_ };
         for (int i = 0; i < ps.nrUStep; ++i) {
             Q_.block(i * ps.uDim, i * ps.uDim, ps.uDim, ps.uDim) = mat;
-            c_.segment(i * ps.uDim, ps.uDim) = vec;
+            // c_.segment(i * ps.uDim, ps.uDim) = vec;
             E_.block(i * ps.uDim, i * ps.uDim, ps.uDim, ps.uDim).setZero();
             f_.segment(i * ps.uDim, ps.uDim) = vec;
+            c_.segment(i * ps.uDim, ps.uDim) = f_.segment(i * ps.uDim, ps.uDim);
         }
     }
 }
@@ -187,17 +192,19 @@ void MixedCost::update(const PreviewSystem& ps)
     if (fullSizeEntry_) {
         Eigen::MatrixXd tmp = M_ * ps.Psi + N_;
         Q_.noalias() = tmp.transpose() * weights_.asDiagonal() * tmp;
-        c_.noalias() = (M_ * (ps.Phi * ps.x0 + ps.xi) - p_).transpose() * weights_.asDiagonal() * tmp;
+        // c_.noalias() = (M_ * (ps.Phi * ps.x0 + ps.xi) - p_).transpose() * weights_.asDiagonal() * tmp;
         E_.noalias() = (M_ * ps.Phi).transpose() * weights_.asDiagonal() * tmp;
         f_.noalias() = (M_ * ps.xi - p_).transpose() * weights_.asDiagonal() * tmp;
+        c_.noalias() = E_.transpose() * ps.x0 + f_;
     } else {
         for (int i = 0; i < ps.nrUStep; ++i) { // Can be optimized. Lot of sums of zero here
             Eigen::MatrixXd tmp{ M_ * ps.Psi.block(i * ps.xDim, 0, ps.xDim, ps.fullUDim) };
             tmp.block(0, i * ps.uDim, M_.rows(), ps.uDim).noalias() += N_;
             Q_.noalias() += tmp.transpose() * weights_.asDiagonal() * tmp;
-            c_.noalias() += (M_ * (ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim) * ps.x0 + ps.xi.segment(i * ps.xDim, ps.xDim)) - p_).transpose() * weights_.asDiagonal() * tmp;
+            // c_.noalias() += (M_ * (ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim) * ps.x0 + ps.xi.segment(i * ps.xDim, ps.xDim)) - p_).transpose() * weights_.asDiagonal() * tmp;
             E_.noalias() += (M_ * ps.Phi.block(i * ps.xDim, 0, ps.xDim, ps.xDim)).transpose() * weights_.asDiagonal() * tmp;
             f_.noalias() += (M_ * ps.xi.segment(i * ps.xDim, ps.xDim) - p_).transpose() * weights_.asDiagonal() * tmp;
+            c_.noalias() += E_.transpose() * ps.x0 + f_;
         }
     }
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,3 +13,4 @@ endmacro(addTest)
 
 addTest(TestSolvers)
 addTest(TestLMPC)
+addTest(TestLMPC_InitialState)

--- a/tests/TestLMPC_InitialState.cpp
+++ b/tests/TestLMPC_InitialState.cpp
@@ -99,7 +99,7 @@ TEST_CASE_FIXTURE(BoundedSystem, "INITIAL_STATE_LMPC")
 
     lmpc.addCost(tc);
     lmpc.addCost(tac);
-    // lmpc.addCost(cc);
+    lmpc.addCost(cc);
     lmpc.addCost(mc);
     lmpc.addConstraint(tcstr);
     lmpc.addConstraint(ccstr);
@@ -111,7 +111,7 @@ TEST_CASE_FIXTURE(BoundedSystem, "INITIAL_STATE_LMPC")
 
     lmpc.removeCost(tc);
     lmpc.removeCost(tac);
-    // lmpc.removeCost(cc);
+    lmpc.removeCost(cc);
     lmpc.removeCost(mc);
     lmpc.removeConstraint(tcstr);
     lmpc.removeConstraint(ccstr);

--- a/tests/TestLMPC_InitialState.cpp
+++ b/tests/TestLMPC_InitialState.cpp
@@ -1,0 +1,140 @@
+/*
+ * Author: Niels Dehio
+ */
+
+#include "doctest.h"
+#include "systems.h"
+#include "tools.h"
+#include <Eigen/Core>
+#include <algorithm>
+#include "LMPC.h"
+#include "InitialStateLMPC.h"
+#include "PreviewSystem.h"
+#include "constraints.h"
+#include "costFunctions.h"
+#include "QuadProgSolver.h"
+#ifdef EIGEN_QLD_FOUND
+#include "QLDSolver.h"
+#endif
+#ifdef EIGEN_LSSOL_FOUND
+#include "LSSOLSolver.h"
+#endif
+#ifdef EIGEN_GUROBI_FOUND
+#include "GUROBISolver.h"
+#endif
+#ifdef EIGEN_OSQP_FOUND
+#include "OSQPSolver.h"
+#endif
+
+#include <memory>
+#include <numeric>
+#include <vector>
+#include <unsupported/Eigen/MatrixFunctions> // for matrix exponential
+
+TEST_CASE_FIXTURE(BoundedSystem, "INITIAL_STATE_LMPC")
+{
+    //define costs and constraints
+    const int numCost = 1;
+    const int numCstr = 1;
+    const int s_dim = 2;
+    const int u_dim = 1;
+    const double factor = 100;
+    Eigen::MatrixXd tcMat = Eigen::MatrixXd::Random(numCost,s_dim);
+    Eigen::VectorXd tcVec = factor*Eigen::VectorXd::Random(numCost);
+    Eigen::MatrixXd tacMat = Eigen::MatrixXd::Random(numCost,s_dim);
+    Eigen::VectorXd tacVec = factor*Eigen::VectorXd::Random(numCost);
+    Eigen::MatrixXd ccMat = Eigen::MatrixXd::Random(numCost,u_dim);
+    Eigen::VectorXd ccVec = factor*Eigen::VectorXd::Random(numCost);
+    Eigen::MatrixXd mcStateMat = Eigen::MatrixXd::Random(numCost,s_dim);
+    Eigen::MatrixXd mcControlMat = Eigen::MatrixXd::Random(numCost,u_dim);
+    Eigen::VectorXd mcVec = factor*Eigen::VectorXd::Random(numCost);
+
+    Eigen::MatrixXd tcstrMat = Eigen::MatrixXd::Random(numCstr,s_dim);
+    Eigen::VectorXd tcstrVec = factor*Eigen::VectorXd::Random(numCstr);
+    Eigen::MatrixXd ccstrMat = Eigen::MatrixXd::Random(numCstr,u_dim);
+    Eigen::VectorXd ccstrVec = factor*Eigen::VectorXd::Random(numCstr);
+    Eigen::MatrixXd mcstrStateMat = Eigen::MatrixXd::Random(numCstr,s_dim);
+    Eigen::MatrixXd mcstrControlMat = Eigen::MatrixXd::Random(numCstr,u_dim);
+    Eigen::VectorXd mcstrVec = factor*Eigen::VectorXd::Random(numCstr);
+    Eigen::VectorXd tbcstrVec = factor*Eigen::VectorXd::Ones(s_dim);
+    Eigen::VectorXd cbcstrVec = factor*Eigen::VectorXd::Ones(u_dim);
+
+    std::shared_ptr<copra::TrajectoryCost> tc;
+    std::shared_ptr<copra::TargetCost> tac;
+    std::shared_ptr<copra::ControlCost> cc;
+    std::shared_ptr<copra::MixedCost> mc;
+    std::shared_ptr<copra::TrajectoryConstraint> tcstr;
+    std::shared_ptr<copra::ControlConstraint> ccstr;
+    std::shared_ptr<copra::MixedConstraint> mcstr;
+    std::shared_ptr<copra::TrajectoryBoundConstraint> tbcstr;
+    std::shared_ptr<copra::ControlBoundConstraint> cbcstr;
+
+    tc = std::make_shared<copra::TrajectoryCost>(tcMat, tcVec);
+    tac = std::make_shared<copra::TargetCost>(tacMat, tacVec);
+    cc = std::make_shared<copra::ControlCost>(ccMat, ccVec);
+    mc = std::make_shared<copra::MixedCost>(mcStateMat, mcControlMat, mcVec);
+    tcstr = std::make_shared<copra::TrajectoryConstraint>(tcstrMat, tcstrVec, /* isInequalityConstraint = */ true);
+    ccstr = std::make_shared<copra::ControlConstraint>(ccstrMat, ccstrVec, /* isInequalityConstraint = */ true);
+    mcstr = std::make_shared<copra::MixedConstraint>(mcstrStateMat, mcstrControlMat, mcstrVec, /* isInequalityConstraint = */ true);
+    tbcstr = std::make_shared<copra::TrajectoryBoundConstraint>(-tbcstrVec, tbcstrVec);
+    cbcstr = std::make_shared<copra::ControlBoundConstraint>(-cbcstrVec, cbcstrVec);
+
+    tc->weight(1);
+    tac->weight(1);
+    cc->weight(1);
+    mc->weight(1);
+
+    //initialize preview-system and lmpc
+    std::shared_ptr<copra::PreviewSystem> previewSystem_;
+    const copra::SolverFlag solverFlag = copra::SolverFlag::QLD; //or use another flag
+    previewSystem_ = std::make_shared<copra::PreviewSystem>();
+    copra::InitialStateLMPC lmpc = copra::InitialStateLMPC(previewSystem_, solverFlag);
+    // copra::LMPC lmpc = copra::LMPC(previewSystem_, solverFlag); //for comparison
+    const int nbSteps_ = 10;
+    const double dt = 0.001;
+    Eigen::MatrixXd combi_c = Eigen::MatrixXd::Zero(s_dim+u_dim,s_dim+u_dim);
+    Eigen::MatrixXd combi_d = Eigen::MatrixXd::Zero(s_dim+u_dim,s_dim+u_dim);
+    combi_c.topRightCorner(s_dim,s_dim).setIdentity();
+    combi_d = (combi_c*dt).exp(); //matrix exponential
+    Eigen::VectorXd biasVector2;
+    biasVector2 = Eigen::VectorXd::Zero(s_dim);
+    Eigen::VectorXd s_init;
+    s_init = Eigen::VectorXd::Random(s_dim);
+    previewSystem_->system( combi_d.topLeftCorner(s_dim, s_dim), 
+                            combi_d.topRightCorner(s_dim, u_dim), 
+                            biasVector2, s_init, nbSteps_ );
+
+    //specify and solve lmpc
+    lmpc.initializeController(previewSystem_);
+    lmpc.resetInitialStateBounds(Eigen::VectorXd::Zero(s_dim), Eigen::VectorXd::Zero(s_dim));
+
+    lmpc.addCost(tc);
+    lmpc.addCost(tac);
+    // lmpc.addCost(cc);
+    lmpc.addCost(mc);
+    lmpc.addConstraint(tcstr);
+    lmpc.addConstraint(ccstr);
+    lmpc.addConstraint(mcstr);
+    // lmpc.addConstraint(tbcstr);
+    // lmpc.addConstraint(cbcstr);
+
+    bool solutionFound = lmpc.solve();
+
+    lmpc.removeCost(tc);
+    lmpc.removeCost(tac);
+    // lmpc.removeCost(cc);
+    lmpc.removeCost(mc);
+    lmpc.removeConstraint(tcstr);
+    lmpc.removeConstraint(ccstr);
+    lmpc.removeConstraint(mcstr);
+    // lmpc.removeConstraint(tbcstr);
+    // lmpc.removeConstraint(cbcstr);
+
+    if(solutionFound){
+        std::cout << "commands: " << lmpc.control().transpose() << std::endl;
+        std::cout << "states: " << lmpc.trajectory().transpose() << std::endl;
+    }
+    else{
+        std::cout << "no solution found" << std::endl;
+    }
+}

--- a/tests/TestLMPC_InitialState.cpp
+++ b/tests/TestLMPC_InitialState.cpp
@@ -29,7 +29,6 @@
 #include <memory>
 #include <numeric>
 #include <vector>
-#include <unsupported/Eigen/MatrixFunctions> // for matrix exponential
 
 TEST_CASE_FIXTURE(BoundedSystem, "INITIAL_STATE_LMPC")
 {
@@ -90,19 +89,13 @@ TEST_CASE_FIXTURE(BoundedSystem, "INITIAL_STATE_LMPC")
     previewSystem_ = std::make_shared<copra::PreviewSystem>();
     copra::InitialStateLMPC lmpc = copra::InitialStateLMPC(previewSystem_, solverFlag);
     // copra::LMPC lmpc = copra::LMPC(previewSystem_, solverFlag); //for comparison
+    Eigen::MatrixXd combi = Eigen::MatrixXd::Random(s_dim+u_dim,s_dim+u_dim);
+    Eigen::VectorXd biasVector = Eigen::VectorXd::Zero(s_dim);
+    Eigen::VectorXd s_init = Eigen::VectorXd::Random(s_dim);
     const int nbSteps_ = 10;
-    const double dt = 0.001;
-    Eigen::MatrixXd combi_c = Eigen::MatrixXd::Zero(s_dim+u_dim,s_dim+u_dim);
-    Eigen::MatrixXd combi_d = Eigen::MatrixXd::Zero(s_dim+u_dim,s_dim+u_dim);
-    combi_c.topRightCorner(s_dim,s_dim).setIdentity();
-    combi_d = (combi_c*dt).exp(); //matrix exponential
-    Eigen::VectorXd biasVector2;
-    biasVector2 = Eigen::VectorXd::Zero(s_dim);
-    Eigen::VectorXd s_init;
-    s_init = Eigen::VectorXd::Random(s_dim);
-    previewSystem_->system( combi_d.topLeftCorner(s_dim, s_dim), 
-                            combi_d.topRightCorner(s_dim, u_dim), 
-                            biasVector2, s_init, nbSteps_ );
+    previewSystem_->system( combi.topLeftCorner(s_dim, s_dim), 
+                            combi.topRightCorner(s_dim, u_dim), 
+                            biasVector, s_init, nbSteps_ );
 
     //specify and solve lmpc
     lmpc.initializeController(previewSystem_);

--- a/tests/TestLMPC_InitialState.cpp
+++ b/tests/TestLMPC_InitialState.cpp
@@ -4,10 +4,6 @@
 
 #include "doctest.h"
 #include "systems.h"
-#include "tools.h"
-#include <Eigen/Core>
-#include <algorithm>
-#include "LMPC.h"
 #include "InitialStateLMPC.h"
 #include "PreviewSystem.h"
 #include "constraints.h"

--- a/tests/TestLMPC_InitialState.cpp
+++ b/tests/TestLMPC_InitialState.cpp
@@ -26,33 +26,293 @@
 #include <numeric>
 #include <vector>
 
-TEST_CASE_FIXTURE(BoundedSystem, "INITIAL_STATE_LMPC")
-{
+void run_comparison_test(const bool fullSizeEntry){
     //define costs and constraints
     const int numCost = 1;
     const int numCstr = 1;
-    const int s_dim = 2;
-    const int u_dim = 1;
-    const double factor = 100;
-    Eigen::MatrixXd tcMat = Eigen::MatrixXd::Random(numCost,s_dim);
-    Eigen::VectorXd tcVec = factor*Eigen::VectorXd::Random(numCost);
-    Eigen::MatrixXd tacMat = Eigen::MatrixXd::Random(numCost,s_dim);
-    Eigen::VectorXd tacVec = factor*Eigen::VectorXd::Random(numCost);
-    Eigen::MatrixXd ccMat = Eigen::MatrixXd::Random(numCost,u_dim);
-    Eigen::VectorXd ccVec = factor*Eigen::VectorXd::Random(numCost);
-    Eigen::MatrixXd mcStateMat = Eigen::MatrixXd::Random(numCost,s_dim);
-    Eigen::MatrixXd mcControlMat = Eigen::MatrixXd::Random(numCost,u_dim);
-    Eigen::VectorXd mcVec = factor*Eigen::VectorXd::Random(numCost);
+    const int xDim = 2;
+    const int uDim = 1;
+    const double factor = 10;
+    const int nbSteps_ = 10;
+    int U;
+    int X;
+    if(fullSizeEntry){
+        //this option results for all costs and constraints in fullSizeEntry==true 
+        U = nbSteps_; //NOTE: nbSteps_ == previewSystem_->fullUDim
+        X = nbSteps_+1; //NOTE: nbSteps_+1 == previewSystem_->fullXDim
+    }
+    else{
+        //this option results for all costs and constraints in fullSizeEntry==false
+        U = 1; 
+        X = 1; 
+    }
 
-    Eigen::MatrixXd tcstrMat = Eigen::MatrixXd::Random(numCstr,s_dim);
-    Eigen::VectorXd tcstrVec = factor*Eigen::VectorXd::Random(numCstr);
-    Eigen::MatrixXd ccstrMat = Eigen::MatrixXd::Random(numCstr,u_dim);
-    Eigen::VectorXd ccstrVec = factor*Eigen::VectorXd::Random(numCstr);
-    Eigen::MatrixXd mcstrStateMat = Eigen::MatrixXd::Random(numCstr,s_dim);
-    Eigen::MatrixXd mcstrControlMat = Eigen::MatrixXd::Random(numCstr,u_dim);
-    Eigen::VectorXd mcstrVec = factor*Eigen::VectorXd::Random(numCstr);
-    Eigen::VectorXd tbcstrVec = factor*Eigen::VectorXd::Ones(s_dim);
-    Eigen::VectorXd cbcstrVec = factor*Eigen::VectorXd::Ones(u_dim);
+    Eigen::MatrixXd tcMat = Eigen::MatrixXd::Ones(numCost,xDim);
+    Eigen::VectorXd tcVec = factor*Eigen::VectorXd::Ones(numCost * X);
+    Eigen::MatrixXd tacMat = Eigen::MatrixXd::Ones(numCost,xDim);
+    Eigen::VectorXd tacVec = factor*Eigen::VectorXd::Ones(numCost);
+    Eigen::MatrixXd ccMat = Eigen::MatrixXd::Ones(numCost,uDim);
+    Eigen::VectorXd ccVec = factor*Eigen::VectorXd::Ones(numCost * U);
+    Eigen::MatrixXd mcStateMat = Eigen::MatrixXd::Ones(numCost,xDim);
+    Eigen::MatrixXd mcControlMat = Eigen::MatrixXd::Ones(numCost,uDim);
+    Eigen::VectorXd mcVec = factor*Eigen::VectorXd::Ones(numCost * U);
+    Eigen::MatrixXd tcstrMat = Eigen::MatrixXd::Ones(numCstr,xDim);
+    Eigen::VectorXd tcstrVec = factor*Eigen::VectorXd::Ones(numCstr * X);
+    Eigen::MatrixXd ccstrMat = Eigen::MatrixXd::Ones(numCstr,uDim);
+    Eigen::VectorXd ccstrVec = factor*Eigen::VectorXd::Ones(numCstr * U);
+    Eigen::MatrixXd mcstrStateMat = Eigen::MatrixXd::Ones(numCstr,xDim);
+    Eigen::MatrixXd mcstrControlMat = Eigen::MatrixXd::Ones(numCstr,uDim);
+    Eigen::VectorXd mcstrVec = factor*Eigen::VectorXd::Ones(numCstr * U);
+    Eigen::VectorXd tbcstrVecL = (-std::numeric_limits<double>::infinity())*Eigen::VectorXd::Ones(xDim * X);
+    Eigen::VectorXd tbcstrVecU = (+std::numeric_limits<double>::infinity())*Eigen::VectorXd::Ones(xDim * X);
+    // Eigen::VectorXd tbcstrVecL = (-1000)*Eigen::VectorXd::Ones(xDim * X); //TODO why does this fail?
+    // Eigen::VectorXd tbcstrVecU = (+1000)*Eigen::VectorXd::Ones(xDim * X); //TODO why does this fail?
+    Eigen::VectorXd cbcstrVecL = (-3)*Eigen::VectorXd::Ones(uDim * U);
+    Eigen::VectorXd cbcstrVecU = (+3)*Eigen::VectorXd::Ones(uDim * U);
+
+
+    std::shared_ptr<copra::TrajectoryCost> tcA;
+    std::shared_ptr<copra::TargetCost> tacA;
+    std::shared_ptr<copra::ControlCost> ccA;
+    std::shared_ptr<copra::MixedCost> mcA;
+    std::shared_ptr<copra::TrajectoryConstraint> tcstrA;
+    std::shared_ptr<copra::ControlConstraint> ccstrA;
+    std::shared_ptr<copra::MixedConstraint> mcstrA;
+    std::shared_ptr<copra::TrajectoryBoundConstraint> tbcstrA;
+    std::shared_ptr<copra::ControlBoundConstraint> cbcstrA;
+    tcA = std::make_shared<copra::TrajectoryCost>(tcMat, tcVec);
+    tacA = std::make_shared<copra::TargetCost>(tacMat, tacVec);
+    ccA = std::make_shared<copra::ControlCost>(ccMat, ccVec);
+    mcA = std::make_shared<copra::MixedCost>(mcStateMat, mcControlMat, mcVec);
+    tcstrA = std::make_shared<copra::TrajectoryConstraint>(tcstrMat, tcstrVec, /* isInequalityConstraint = */ true);
+    ccstrA = std::make_shared<copra::ControlConstraint>(ccstrMat, ccstrVec, /* isInequalityConstraint = */ true);
+    mcstrA = std::make_shared<copra::MixedConstraint>(mcstrStateMat, mcstrControlMat, mcstrVec, /* isInequalityConstraint = */ true);
+    tbcstrA = std::make_shared<copra::TrajectoryBoundConstraint>(tbcstrVecL, tbcstrVecU);
+    cbcstrA = std::make_shared<copra::ControlBoundConstraint>(cbcstrVecL, cbcstrVecU);
+    tcA->autoSpan();
+    tacA->autoSpan();
+    ccA->autoSpan();
+    mcA->autoSpan();
+    tcstrA->autoSpan();
+    ccstrA->autoSpan();
+    mcstrA->autoSpan();
+    tbcstrA->autoSpan();
+    cbcstrA->autoSpan();
+    tcA->weight(1);
+    tacA->weight(1);
+    ccA->weight(1);
+    mcA->weight(1);
+
+
+    std::shared_ptr<copra::TrajectoryCost> tcB;
+    std::shared_ptr<copra::TargetCost> tacB;
+    std::shared_ptr<copra::ControlCost> ccB;
+    std::shared_ptr<copra::MixedCost> mcB;
+    std::shared_ptr<copra::TrajectoryConstraint> tcstrB;
+    std::shared_ptr<copra::ControlConstraint> ccstrB;
+    std::shared_ptr<copra::MixedConstraint> mcstrB;
+    std::shared_ptr<copra::TrajectoryBoundConstraint> tbcstrB;
+    std::shared_ptr<copra::ControlBoundConstraint> cbcstrB;
+    tcB = std::make_shared<copra::TrajectoryCost>(tcMat, tcVec);
+    tacB = std::make_shared<copra::TargetCost>(tacMat, tacVec);
+    ccB = std::make_shared<copra::ControlCost>(ccMat, ccVec);
+    mcB = std::make_shared<copra::MixedCost>(mcStateMat, mcControlMat, mcVec);
+    tcstrB = std::make_shared<copra::TrajectoryConstraint>(tcstrMat, tcstrVec, /* isInequalityConstraint = */ true);
+    ccstrB = std::make_shared<copra::ControlConstraint>(ccstrMat, ccstrVec, /* isInequalityConstraint = */ true);
+    mcstrB = std::make_shared<copra::MixedConstraint>(mcstrStateMat, mcstrControlMat, mcstrVec, /* isInequalityConstraint = */ true);
+    tbcstrB = std::make_shared<copra::TrajectoryBoundConstraint>(tbcstrVecL, tbcstrVecU);
+    cbcstrB = std::make_shared<copra::ControlBoundConstraint>(cbcstrVecL, cbcstrVecU);
+    tcB->autoSpan();
+    tacB->autoSpan();
+    ccB->autoSpan();
+    mcB->autoSpan();
+    tcstrB->autoSpan();
+    ccstrB->autoSpan();
+    mcstrB->autoSpan();
+    tbcstrB->autoSpan();
+    cbcstrB->autoSpan();
+    tcB->weight(1);
+    tacB->weight(1);
+    ccB->weight(1);
+    mcB->weight(1);
+
+
+    //initialize preview-system and lmpc
+    const Eigen::MatrixXd combi = Eigen::MatrixXd::Ones(xDim+uDim,xDim+uDim);
+    const Eigen::VectorXd biasVector = Eigen::VectorXd::Zero(xDim);
+    const Eigen::VectorXd s_init = Eigen::VectorXd::Zero(xDim);
+    std::shared_ptr<copra::PreviewSystem> previewSystem;
+    previewSystem = std::make_shared<copra::PreviewSystem>();
+    previewSystem->system( combi.topLeftCorner(xDim, xDim), 
+                            combi.topRightCorner(xDim, uDim), 
+                            biasVector, s_init, nbSteps_ );
+    const copra::SolverFlag solverFlag = copra::SolverFlag::QLD; //or use another flag
+
+
+    //specify and solve lmpc
+    copra::LMPC lmpcA = copra::LMPC(previewSystem, solverFlag);
+    lmpcA.initializeController(previewSystem);
+    lmpcA.addCost(tcA);
+    lmpcA.addCost(tacA);
+    lmpcA.addCost(ccA);
+    lmpcA.addCost(mcA);
+    lmpcA.addConstraint(tcstrA);
+    lmpcA.addConstraint(ccstrA);
+    lmpcA.addConstraint(mcstrA);
+    lmpcA.addConstraint(tbcstrA);
+    lmpcA.addConstraint(cbcstrA);
+    REQUIRE(lmpcA.solve());
+    lmpcA.removeCost(tcA);
+    lmpcA.removeCost(tacA);
+    lmpcA.removeCost(ccA);
+    lmpcA.removeCost(mcA);
+    lmpcA.removeConstraint(tcstrA);
+    lmpcA.removeConstraint(ccstrA);
+    lmpcA.removeConstraint(mcstrA);
+    lmpcA.removeConstraint(tbcstrA);
+    lmpcA.removeConstraint(cbcstrA);
+    
+
+    copra::InitialStateLMPC lmpcB = copra::InitialStateLMPC(previewSystem, solverFlag);
+    lmpcB.initializeController(previewSystem);
+    lmpcB.addCost(tcB);
+    lmpcB.addCost(tacB);
+    lmpcB.addCost(ccB);
+    lmpcB.addCost(mcB);
+    lmpcB.addConstraint(tcstrB);
+    lmpcB.addConstraint(ccstrB);
+    lmpcB.addConstraint(mcstrB);
+    lmpcB.addConstraint(tbcstrB);
+    lmpcB.addConstraint(cbcstrB);
+    REQUIRE(lmpcB.solve());
+    lmpcB.removeCost(tcB);
+    lmpcB.removeCost(tacB);
+    lmpcB.removeCost(ccB);
+    lmpcB.removeCost(mcB);
+    lmpcB.removeConstraint(tcstrB);
+    lmpcB.removeConstraint(ccstrB);
+    lmpcB.removeConstraint(mcstrB);
+    lmpcB.removeConstraint(tbcstrB);
+    lmpcB.removeConstraint(cbcstrB);
+
+
+    Eigen::MatrixXd lmpcA_Q = lmpcA.get_Q();
+    Eigen::MatrixXd lmpcA_Aineq = lmpcA.get_Aineq();
+    Eigen::MatrixXd lmpcA_Aeq = lmpcA.get_Aeq();
+    Eigen::VectorXd lmpcA_c = lmpcA.get_c();
+    Eigen::VectorXd lmpcA_bineq = lmpcA.get_bineq();
+    Eigen::VectorXd lmpcA_beq = lmpcA.get_beq();
+    Eigen::VectorXd lmpcA_lb = lmpcA.get_lb();
+    Eigen::VectorXd lmpcA_ub = lmpcA.get_ub();
+
+    Eigen::MatrixXd lmpcB_Q = lmpcB.get_Q();
+    Eigen::MatrixXd lmpcB_Aineq = lmpcB.get_Aineq();
+    Eigen::MatrixXd lmpcB_Aeq = lmpcB.get_Aeq();
+    Eigen::VectorXd lmpcB_c = lmpcB.get_c();
+    Eigen::VectorXd lmpcB_bineq = lmpcB.get_bineq();
+    Eigen::VectorXd lmpcB_beq = lmpcB.get_beq();
+    Eigen::VectorXd lmpcB_lb = lmpcB.get_lb();
+    Eigen::VectorXd lmpcB_ub = lmpcB.get_ub();
+
+    REQUIRE_EQ(lmpcA.get_nrEqConstr(), lmpcB.get_nrEqConstr());
+    REQUIRE_EQ(lmpcA.get_nrIneqConstr(), lmpcB.get_nrIneqConstr());
+
+    REQUIRE_LE((lmpcA_Q - lmpcB_Q).cwiseAbs().maxCoeff(), 1e-6);
+    REQUIRE_LE((lmpcA_c - lmpcB_c).cwiseAbs().maxCoeff(), 1e-6);
+    REQUIRE_LE((lmpcA_lb - lmpcB_lb).cwiseAbs().maxCoeff(), 1e-6);
+    REQUIRE_LE((lmpcA_ub - lmpcB_ub).cwiseAbs().maxCoeff(), 1e-6);
+    if(lmpcA.get_nrEqConstr()){
+        REQUIRE_LE((lmpcA_Aeq - lmpcB_Aeq).cwiseAbs().maxCoeff(), 1e-6);
+        REQUIRE_LE((lmpcA_beq - lmpcB_beq).cwiseAbs().maxCoeff(), 1e-6);
+    }
+    if(lmpcA.get_nrEqConstr()){
+        REQUIRE_LE((lmpcA_Aineq - lmpcB_Aineq).cwiseAbs().maxCoeff(), 1e-6);
+        REQUIRE_LE((lmpcA_bineq - lmpcB_bineq).cwiseAbs().maxCoeff(), 1e-6);
+    }
+
+    const Eigen::VectorXd commandsA = lmpcA.control();
+    const Eigen::VectorXd statesA = lmpcA.trajectory();
+    const Eigen::VectorXd initialStateA = statesA.head(xDim);
+    const Eigen::VectorXd commandsB = lmpcB.control();
+    const Eigen::VectorXd statesB = lmpcB.trajectory();
+    const Eigen::VectorXd initialStateB = statesB.head(xDim);
+    std::cout << "commandsA: \n " << commandsA.transpose() << std::endl;
+    std::cout << "commandsB: \n " << commandsB.transpose() << std::endl;
+    std::cout << "statesA: \n " << statesA.transpose() << std::endl;
+    std::cout << "statesB: \n " << statesB.transpose() << std::endl;
+    std::cout << "initialStateA: \n " << initialStateA.transpose() << std::endl;
+    std::cout << "initialStateB: \n " << initialStateB.transpose() << std::endl;
+
+    //check if initial state is within its bounds
+    for (auto i = 0; i < xDim; ++i) {
+        CHECK_LE(initialStateA(i), s_init(i) + 1e-6);
+        CHECK_LE(s_init(i), initialStateA(i) + 1e-6);
+        REQUIRE_LE(initialStateA(i), s_init(i) + 1e-6);
+        REQUIRE_LE(s_init(i), initialStateA(i) + 1e-6);
+        
+        CHECK_LE(initialStateB(i), s_init(i) + 1e-6);
+        CHECK_LE(s_init(i), initialStateB(i) + 1e-6);
+        REQUIRE_LE(initialStateB(i), s_init(i) + 1e-6);
+        REQUIRE_LE(s_init(i), initialStateB(i) + 1e-6);
+    }
+}
+
+TEST_CASE_FIXTURE(BoundedSystem, "LMPC_AND_INITIAL-STATE-LMPC_COMPARISON")
+{
+    //NOTE: there are no equality constraints in this test
+    run_comparison_test(true);
+    run_comparison_test(false);
+}
+
+
+// ########################################################################
+// ########################################################################
+// ########################################################################
+
+
+void run_optimization_test(const bool fullSizeEntry){
+    //define costs and constraints
+    const int numCost = 1;
+    const int numCstr = 1;
+    const int xDim = 2;
+    const int uDim = 1;
+    const double factor = 10;
+    const int nbSteps_ = 10;
+    int U;
+    int X;
+    if(fullSizeEntry){
+        //this option results for all costs and constraints in fullSizeEntry==true 
+        U = nbSteps_; //NOTE: nbSteps_ == previewSystem_->fullUDim
+        X = nbSteps_+1; //NOTE: nbSteps_+1 == previewSystem_->fullXDim
+    }
+    else{
+        //this option results for all costs and constraints in fullSizeEntry==false
+        U = 1; 
+        X = 1; 
+    }
+
+    Eigen::MatrixXd tcMat = Eigen::MatrixXd::Ones(numCost,xDim);
+    Eigen::VectorXd tcVec = factor*Eigen::VectorXd::Ones(numCost * X);
+    Eigen::MatrixXd tacMat = Eigen::MatrixXd::Ones(numCost,xDim);
+    Eigen::VectorXd tacVec = factor*Eigen::VectorXd::Ones(numCost);
+    Eigen::MatrixXd ccMat = Eigen::MatrixXd::Ones(numCost,uDim);
+    Eigen::VectorXd ccVec = factor*Eigen::VectorXd::Ones(numCost * U);
+    Eigen::MatrixXd mcStateMat = Eigen::MatrixXd::Ones(numCost,xDim);
+    Eigen::MatrixXd mcControlMat = Eigen::MatrixXd::Ones(numCost,uDim);
+    Eigen::VectorXd mcVec = factor*Eigen::VectorXd::Ones(numCost * U);
+    Eigen::MatrixXd tcstrMat = Eigen::MatrixXd::Ones(numCstr,xDim);
+    Eigen::VectorXd tcstrVec = factor*Eigen::VectorXd::Ones(numCstr * X);
+    Eigen::MatrixXd ccstrMat = Eigen::MatrixXd::Ones(numCstr,uDim);
+    Eigen::VectorXd ccstrVec = factor*Eigen::VectorXd::Ones(numCstr * U);
+    Eigen::MatrixXd mcstrStateMat = Eigen::MatrixXd::Ones(numCstr,xDim);
+    Eigen::MatrixXd mcstrControlMat = Eigen::MatrixXd::Ones(numCstr,uDim);
+    Eigen::VectorXd mcstrVec = factor*Eigen::VectorXd::Ones(numCstr * U);
+    Eigen::VectorXd tbcstrVecL = (-std::numeric_limits<double>::infinity())*Eigen::VectorXd::Ones(xDim * X);
+    Eigen::VectorXd tbcstrVecU = (+std::numeric_limits<double>::infinity())*Eigen::VectorXd::Ones(xDim * X);
+    // Eigen::VectorXd tbcstrVecL = (-1000)*Eigen::VectorXd::Ones(xDim * X); //TODO why does this fail?
+    // Eigen::VectorXd tbcstrVecU = (+1000)*Eigen::VectorXd::Ones(xDim * X); //TODO why does this fail?
+    Eigen::VectorXd cbcstrVecL = (-3)*Eigen::VectorXd::Ones(uDim * U);
+    Eigen::VectorXd cbcstrVecU = (+3)*Eigen::VectorXd::Ones(uDim * U);
 
     std::shared_ptr<copra::TrajectoryCost> tc;
     std::shared_ptr<copra::TargetCost> tac;
@@ -63,7 +323,6 @@ TEST_CASE_FIXTURE(BoundedSystem, "INITIAL_STATE_LMPC")
     std::shared_ptr<copra::MixedConstraint> mcstr;
     std::shared_ptr<copra::TrajectoryBoundConstraint> tbcstr;
     std::shared_ptr<copra::ControlBoundConstraint> cbcstr;
-
     tc = std::make_shared<copra::TrajectoryCost>(tcMat, tcVec);
     tac = std::make_shared<copra::TargetCost>(tacMat, tacVec);
     cc = std::make_shared<copra::ControlCost>(ccMat, ccVec);
@@ -71,32 +330,43 @@ TEST_CASE_FIXTURE(BoundedSystem, "INITIAL_STATE_LMPC")
     tcstr = std::make_shared<copra::TrajectoryConstraint>(tcstrMat, tcstrVec, /* isInequalityConstraint = */ true);
     ccstr = std::make_shared<copra::ControlConstraint>(ccstrMat, ccstrVec, /* isInequalityConstraint = */ true);
     mcstr = std::make_shared<copra::MixedConstraint>(mcstrStateMat, mcstrControlMat, mcstrVec, /* isInequalityConstraint = */ true);
-    tbcstr = std::make_shared<copra::TrajectoryBoundConstraint>(-tbcstrVec, tbcstrVec);
-    cbcstr = std::make_shared<copra::ControlBoundConstraint>(-cbcstrVec, cbcstrVec);
-
+    tbcstr = std::make_shared<copra::TrajectoryBoundConstraint>(tbcstrVecL, tbcstrVecU);
+    cbcstr = std::make_shared<copra::ControlBoundConstraint>(cbcstrVecL, cbcstrVecU);
+    tc->autoSpan();
+    tac->autoSpan();
+    cc->autoSpan();
+    mc->autoSpan();
+    tcstr->autoSpan();
+    ccstr->autoSpan();
+    mcstr->autoSpan();
+    tbcstr->autoSpan();
+    cbcstr->autoSpan();
     tc->weight(1);
     tac->weight(1);
     cc->weight(1);
     mc->weight(1);
 
+
     //initialize preview-system and lmpc
-    std::shared_ptr<copra::PreviewSystem> previewSystem_;
-    const copra::SolverFlag solverFlag = copra::SolverFlag::QLD; //or use another flag
-    previewSystem_ = std::make_shared<copra::PreviewSystem>();
-    copra::InitialStateLMPC lmpc = copra::InitialStateLMPC(previewSystem_, solverFlag);
-    // copra::LMPC lmpc = copra::LMPC(previewSystem_, solverFlag); //for comparison
-    Eigen::MatrixXd combi = Eigen::MatrixXd::Random(s_dim+u_dim,s_dim+u_dim);
-    Eigen::VectorXd biasVector = Eigen::VectorXd::Zero(s_dim);
-    Eigen::VectorXd s_init = Eigen::VectorXd::Random(s_dim);
-    const int nbSteps_ = 10;
-    previewSystem_->system( combi.topLeftCorner(s_dim, s_dim), 
-                            combi.topRightCorner(s_dim, u_dim), 
+    const Eigen::MatrixXd combi = Eigen::MatrixXd::Ones(xDim+uDim,xDim+uDim);
+    const Eigen::VectorXd biasVector = Eigen::VectorXd::Zero(xDim);
+    const Eigen::VectorXd s_init = Eigen::VectorXd::Zero(xDim);
+    std::shared_ptr<copra::PreviewSystem> previewSystem;
+    previewSystem = std::make_shared<copra::PreviewSystem>();
+    previewSystem->system( combi.topLeftCorner(xDim, xDim), 
+                            combi.topRightCorner(xDim, uDim), 
                             biasVector, s_init, nbSteps_ );
+    const copra::SolverFlag solverFlag = copra::SolverFlag::QLD; //or use another flag
 
     //specify and solve lmpc
-    lmpc.initializeController(previewSystem_);
-    lmpc.resetInitialStateBounds(Eigen::VectorXd::Zero(s_dim), Eigen::VectorXd::Zero(s_dim));
-
+    copra::InitialStateLMPC lmpc = copra::InitialStateLMPC(previewSystem, solverFlag);
+    lmpc.initializeController(previewSystem);
+    const Eigen::VectorXd initialState_lowerBound = (-1)*Eigen::VectorXd::Ones(xDim); //this allows optimization of the initial state
+    const Eigen::VectorXd initialState_upperBound = (+1)*Eigen::VectorXd::Ones(xDim); //this allows prevents optimization of the initial state
+    lmpc.resetInitialStateBounds(initialState_lowerBound, initialState_upperBound);
+    Eigen::MatrixXd R = (1e-6)*Eigen::MatrixXd::Identity(xDim,xDim); // ensure that R is positive definite
+    Eigen::VectorXd r = Eigen::VectorXd::Zero(xDim);
+    lmpc.resetInitialStateCost(R, r);
     lmpc.addCost(tc);
     lmpc.addCost(tac);
     lmpc.addCost(cc);
@@ -104,11 +374,9 @@ TEST_CASE_FIXTURE(BoundedSystem, "INITIAL_STATE_LMPC")
     lmpc.addConstraint(tcstr);
     lmpc.addConstraint(ccstr);
     lmpc.addConstraint(mcstr);
-    // lmpc.addConstraint(tbcstr);
-    // lmpc.addConstraint(cbcstr);
-
-    bool solutionFound = lmpc.solve();
-
+    lmpc.addConstraint(tbcstr);
+    lmpc.addConstraint(cbcstr);
+    REQUIRE(lmpc.solve());
     lmpc.removeCost(tc);
     lmpc.removeCost(tac);
     lmpc.removeCost(cc);
@@ -116,14 +384,28 @@ TEST_CASE_FIXTURE(BoundedSystem, "INITIAL_STATE_LMPC")
     lmpc.removeConstraint(tcstr);
     lmpc.removeConstraint(ccstr);
     lmpc.removeConstraint(mcstr);
-    // lmpc.removeConstraint(tbcstr);
-    // lmpc.removeConstraint(cbcstr);
+    lmpc.removeConstraint(tbcstr);
+    lmpc.removeConstraint(cbcstr);
 
-    if(solutionFound){
-        std::cout << "commands: " << lmpc.control().transpose() << std::endl;
-        std::cout << "states: " << lmpc.trajectory().transpose() << std::endl;
+    const Eigen::VectorXd commands = lmpc.control();
+    const Eigen::VectorXd states = lmpc.trajectory();
+    const Eigen::VectorXd initialState = states.head(xDim);
+    std::cout << "commands: \n " << commands.transpose() << std::endl;
+    std::cout << "states: \n " << states.transpose() << std::endl;
+    std::cout << "initialState: \n " << initialState.transpose() << std::endl;
+
+    //check if initial state is within its bounds
+    for (auto i = 0; i < xDim; ++i) {
+        CHECK_LE(initialState(i), initialState_upperBound(i) + 1e-6);
+        CHECK_LE(initialState_lowerBound(i), initialState(i) + 1e-6);
+        REQUIRE_LE(initialState(i), initialState_upperBound(i) + 1e-6);
+        REQUIRE_LE(initialState_lowerBound(i), initialState(i) + 1e-6);
     }
-    else{
-        std::cout << "no solution found" << std::endl;
-    }
+}
+
+TEST_CASE_FIXTURE(BoundedSystem, "INITIAL-STATE-OPTIMIZATION")
+{
+    //NOTE: there are no equality constraints in this test
+    run_optimization_test(true);
+    run_optimization_test(false);
 }


### PR DESCRIPTION
In this pull request, I added a class `InitialStateLMPC` that derives from `LMPC`. It includes the initial state as additional optimization variables, which may be bounded via the `resetInitialStateBounds()` function.
A separate test file demonstrates its usage. 
The underlying idea is part of my [ICRA-2021 paper](https://hal.archives-ouvertes.fr/hal-02973947/document).