### PR TITLE
extend functionality for evaluating a particular control vector

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-16.04, ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-18.04, ubuntu-20.04, macos-latest, windows-latest]
         build-type: [Debug, RelWithDebInfo]
         compiler: [gcc, clang]
         exclude:
@@ -30,7 +30,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
         submodules: recursive
     - name: Install dependencies

--- a/include/PreviewSystem.h
+++ b/include/PreviewSystem.h
@@ -48,6 +48,11 @@ struct COPRA_DLLAPI PreviewSystem {
      * Fill Phi, Psi, xi in PreviewSystem.
      */
     void updateSystem() noexcept;
+    /*! \brief Compute the trajectory for a particular control vector.
+     * \param control The control vector
+     * \param trajectory The resulting trajectory
+     */
+    void computeTrajectory(const Eigen::VectorXd& control, Eigen::VectorXd& trajectory) noexcept;
     /*! \brief Modify the initial state without the need to update the system. */
     void xInit(const Eigen::VectorXd& xInit) { x0 = xInit; }
 

--- a/include/constraints.h
+++ b/include/constraints.h
@@ -64,6 +64,11 @@ public:
      * \param ps The PreviewSystem
      */
     virtual void update(const PreviewSystem& ps) = 0;
+    /*! \brief Check if the constraint is satisfied for a particular control vector.
+     * \param control The control vector
+     * \param tolerance The tolerance
+     */
+    virtual bool isSatisfied(const Eigen::VectorXd& control, const double tolerance=0) = 0;
     /*! \brief Return the type of the constraint. \see ConstraintFlag */
     virtual ConstraintFlag constraintType() const noexcept = 0;
     /*! \brief Return the name of the constraint. */
@@ -134,6 +139,7 @@ public:
     void autoSpan() override;
     void initializeConstraint(const PreviewSystem& ps) override;
     void update(const PreviewSystem& ps) override;
+    bool isSatisfied(const Eigen::VectorXd& control, const double tolerance=0) override;
     ConstraintFlag constraintType() const noexcept override;
 
 private:
@@ -170,6 +176,7 @@ public:
     void autoSpan() override;
     void initializeConstraint(const PreviewSystem& ps) override;
     void update(const PreviewSystem& ps) override;
+    bool isSatisfied(const Eigen::VectorXd& control, const double tolerance=0) override;
     ConstraintFlag constraintType() const noexcept override;
 
 private:
@@ -211,6 +218,7 @@ public:
     void autoSpan() override;
     void initializeConstraint(const PreviewSystem& ps) override;
     void update(const PreviewSystem& ps) override;
+    bool isSatisfied(const Eigen::VectorXd& control, const double tolerance=0) override;
     ConstraintFlag constraintType() const noexcept override;
 
 private:
@@ -257,6 +265,7 @@ public:
     void autoSpan() override;
     void initializeConstraint(const PreviewSystem& ps) override;
     void update(const PreviewSystem& ps) override;
+    bool isSatisfied(const Eigen::VectorXd& control, const double tolerance=0) override;
     ConstraintFlag constraintType() const noexcept override;
 
 private:
@@ -293,6 +302,7 @@ public:
     void autoSpan() override;
     void initializeConstraint(const PreviewSystem& ps) override;
     void update(const PreviewSystem& ps) override;
+    bool isSatisfied(const Eigen::VectorXd& control, const double tolerance=0) override;
     ConstraintFlag constraintType() const noexcept override;
     /*! \brief Return the lower bound of the constraint */
     const Eigen::VectorXd& lower() { return lb_; }

--- a/include/costFunctions.h
+++ b/include/costFunctions.h
@@ -41,6 +41,12 @@ public:
      */
     virtual void initializeCost(const PreviewSystem& ps);
 
+    /*! \brief Compute the cost value for a particular control input
+     * \param control The control vector \f$U\f$.
+     * \throw Throw an error if cost is not yet initialized.
+     */
+    virtual double getCostValue(const Eigen::VectorXd& control);
+
     /*! Compute \f$Q\f$ and \f$c\f$.
      * \param ps The preview system.
      */

--- a/src/PreviewSystem.cpp
+++ b/src/PreviewSystem.cpp
@@ -73,4 +73,10 @@ void PreviewSystem::updateSystem() noexcept
     isUpdated = true;
 }
 
+void PreviewSystem::computeTrajectory(const Eigen::VectorXd& control, Eigen::VectorXd& trajectory) noexcept
+{
+    trajectory.resize(fullXDim);
+    trajectory = this->Phi * this->x0 + this->Psi * control + this->xi;
+}
+
 } // namespace copra

--- a/src/constraints.cpp
+++ b/src/constraints.cpp
@@ -83,6 +83,27 @@ void TrajectoryConstraint::update(const PreviewSystem& ps)
     }
 }
 
+bool TrajectoryConstraint::isSatisfied(const Eigen::VectorXd& control, const double tolerance)
+{
+    assert(tolerance>=0);
+    if(isIneq_){
+        if((A_ * control - b_).maxCoeff() > tolerance){
+            return false;
+        }
+        else{
+            return true;
+        }
+    }
+    else{
+        if((A_ * control - b_).maxCoeff() > tolerance || (A_ * control - b_).minCoeff() < -tolerance){
+            return false;
+        }
+        else{
+            return true;
+        }
+    }
+}
+
 ConstraintFlag TrajectoryConstraint::constraintType() const noexcept
 {
     if (isIneq_) {
@@ -144,6 +165,27 @@ void ControlConstraint::update(const PreviewSystem& ps)
         }
         Y_.setZero();
         z_ = b_;
+    }
+}
+
+bool ControlConstraint::isSatisfied(const Eigen::VectorXd& control, const double tolerance)
+{
+    assert(tolerance>=0);
+    if(isIneq_){
+        if((A_ * control - b_).maxCoeff() > tolerance){
+            return false;
+        }
+        else{
+            return true;
+        }
+    }
+    else{
+        if((A_ * control - b_).maxCoeff() > tolerance || (A_ * control - b_).minCoeff() < -tolerance){
+            return false;
+        }
+        else{
+            return true;
+        }
     }
 }
 
@@ -221,6 +263,27 @@ void MixedConstraint::update(const PreviewSystem& ps)
             // b_.segment(i * nrLines, nrLines) = f_ - E_ * (ps.Phi.block(i * xDim, 0, xDim, xDim) * ps.x0 + ps.xi.segment(i * xDim, xDim));
             z_.segment(i * nrLines, nrLines) = f_ - E_ * ps.xi.segment(i * xDim, xDim);
             b_.segment(i * nrLines, nrLines) = z_.segment(i * nrLines, nrLines) - Y_.block(i * nrLines, 0, nrLines, xDim) * ps.x0;
+        }
+    }
+}
+
+bool MixedConstraint::isSatisfied(const Eigen::VectorXd& control, const double tolerance)
+{
+    assert(tolerance>=0);
+    if(isIneq_){
+        if((A_ * control - b_).maxCoeff() > tolerance){
+            return false;
+        }
+        else{
+            return true;
+        }
+    }
+    else{
+        if((A_ * control - b_).maxCoeff() > tolerance || (A_ * control - b_).minCoeff() < -tolerance){
+            return false;
+        }
+        else{
+            return true;
         }
     }
 }
@@ -314,6 +377,17 @@ void TrajectoryBoundConstraint::update(const PreviewSystem& ps)
     }
 }
 
+bool TrajectoryBoundConstraint::isSatisfied(const Eigen::VectorXd& control, const double tolerance)
+{
+    assert(tolerance>=0);
+    if((A_ * control - b_).maxCoeff() > tolerance){
+        return false;
+    }
+    else{
+        return true;
+    }
+}
+
 ConstraintFlag TrajectoryBoundConstraint::constraintType() const noexcept
 {
     return ConstraintFlag::InequalityConstraint;
@@ -363,6 +437,17 @@ void ControlBoundConstraint::update(const PreviewSystem& ps)
             ub_.segment(i * ps.uDim, ps.uDim) = upper_;
             lb_.segment(i * ps.uDim, ps.uDim) = lower_;
         }
+    }
+}
+
+bool ControlBoundConstraint::isSatisfied(const Eigen::VectorXd& control, const double tolerance)
+{
+    assert(tolerance>=0);
+    if((control - ub_).maxCoeff() > tolerance || (control - lb_).minCoeff() < -tolerance ){
+        return false;
+    }
+    else{
+        return true;
     }
 }
 

--- a/src/costFunctions.cpp
+++ b/src/costFunctions.cpp
@@ -29,6 +29,12 @@ void CostFunction::initializeCost(const PreviewSystem& ps)
     f_.resize(ps.fullUDim);
 }
 
+double CostFunction::getCostValue(const Eigen::VectorXd& control)
+{
+    //assert control-vector has the correct dimensions
+    return (0.5 * control.transpose() * Q_ * control - control.transpose() * c_)[0];
+}
+
 /*************************************************************************************************
  *                                  Trajectory Cost Function                                     *
  *************************************************************************************************/


### PR DESCRIPTION
This PR extends the copra functionality for evaluating a particular (maybe non-optimal) control vector:

- costs with a new method getCostValue()
- constraints with a new method isSatisfied()
- previewsystem with a new method computeTrajectory()